### PR TITLE
CFI-3496: Inspire KG technical documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ ORDER BY ?ingredient_name DESC(?sensory_value)
 ### Functional Benefits
 
 <details>
- <summary>Retrieve functional benefits per ingredient</summary>
+ <summary>List of functional benefits per ingredient</summary>
 
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ our [in-house Enterprise KG](https://www.foodpairing.com/industry/research-funda
 
 ## Relevant Resources
 
-The Inspire KG is freely available under [CC BY 4.0 DEED](LICENSE.md) from [here](inspire.ttl). Its specification is
+The Inspire KG is freely available under [CC BY 4.0 DEED](LICENSE.md) for download from [here](inspire.ttl). Its
+specification is
 available [here](https://foodpairing.github.io/inspire_kg/), while the rest of this page presents some more technical
 use cases.
 
@@ -81,7 +82,8 @@ SELECT ?ingredient_name ?ingredient_definition ?ingredient_category_name ?wikida
         skos:definition ?ingredient_definition ;
         :hasIngredientCategory/skos:prefLabel ?ingredient_category_name ;
         rdfs:seeAlso ?wikidata_link .
-} ORDER BY ?ingredient_name
+}
+ORDER BY ?ingredient_name
 ```
 
 </details>
@@ -95,11 +97,12 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 SELECT ?ingredient_name ?ingredient_definition ?ingredient_category_name WHERE {
     ?i a :Ingredient ;
-       skos:prefLabel ?ingredient_name ;
-       skos:definition ?ingredient_definition ;
-       :hasIngredientCategory/skos:prefLabel ?ingredient_category_name .
+        skos:prefLabel ?ingredient_name ;
+        skos:definition ?ingredient_definition ;
+        :hasIngredientCategory/skos:prefLabel ?ingredient_category_name .
     VALUES ?ingredient_category_name { "Pome Fruits"@en "Tropical Fruits"@en }
-} ORDER BY ?ingredient_name
+}
+ORDER BY ?ingredient_name
 ```
 
 </details>
@@ -113,12 +116,14 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 SELECT ?ingredient_name WHERE {
     ?i a :Ingredient ;
-       skos:prefLabel ?ingredient_name ;
-       skos:definition ?ingredient_definition ;
-       :hasIngredientCategory ?c .
+        skos:prefLabel ?ingredient_name ;
+        skos:definition ?ingredient_definition ;
+        :hasIngredientCategory ?c .
+    # Retrieve ingredients no matter how deep in the categories taxonomy they are
     ?c a :IngredientCategory ;
-       skos:broader*/skos:prefLabel "Fruit Category"@en .
-} ORDER BY ?ingredient_name
+        skos:broader*/skos:prefLabel "Fruit Category"@en .
+}
+ORDER BY ?ingredient_name
 ```
 
 </details>
@@ -135,17 +140,18 @@ SELECT ?ingredient_name ?water_footprint WHERE {
     {
         SELECT * WHERE {
             ?i a :Ingredient ;
-               skos:prefLabel ?ingredient_name ;
-               rdfs:seeAlso ?wikidata .
+                skos:prefLabel ?ingredient_name ;
+                rdfs:seeAlso ?wikidata .
             BIND(URI(?wikidata) AS ?wikidataLink)
         }
     }
-    
+
     # Retrieve water footprint per ingredient (wherever available) from Wikidata
     SERVICE <https://query.wikidata.org/sparql> {
         ?wikidataLink <http://www.wikidata.org/prop/direct/P6000> ?water_footprint .
     }
-} ORDER BY ?ingredient_name ?water_footprint
+}
+ORDER BY ?ingredient_name ?water_footprint
 ```
 
 </details>
@@ -158,17 +164,19 @@ SELECT ?ingredient_name ?water_footprint WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_name ?aroma_label ?sensory_value ?aroma_intensity WHERE {
     ?i a :Ingredient ;
-       skos:prefLabel ?ingredient_name ;
-       :hasAroma ?a .
+        skos:prefLabel ?ingredient_name ;
+        :hasAroma ?a .
     ?a a :Aroma ;
-       :sensoryValue ?sensory_value ;
-       :hasSensoryDescriptor ?d .
+        :sensoryValue ?sensory_value ;
+        :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
-       skos:prefLabel ?aroma_label ;
-       :aromaIntensity ?aroma_intensity .
-} ORDER BY ?ingredient_name DESC(?sensory_value)
+        skos:prefLabel ?aroma_label ;
+        :aromaIntensity ?aroma_intensity .
+}
+ORDER BY ?ingredient_name DESC(?sensory_value)
 ```
 
 </details>
@@ -179,6 +187,7 @@ SELECT ?ingredient_name ?aroma_label ?sensory_value ?aroma_intensity WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_name ?taste_label ?sensory_value WHERE {
     ?i a :Ingredient ;
         skos:prefLabel ?ingredient_name ;
@@ -188,7 +197,8 @@ SELECT ?ingredient_name ?taste_label ?sensory_value WHERE {
         :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
         skos:prefLabel ?taste_label .
-} ORDER BY ?ingredient_name DESC(?sensory_value)
+}
+ORDER BY ?ingredient_name DESC(?sensory_value)
 ```
 
 </details>
@@ -199,6 +209,7 @@ SELECT ?ingredient_name ?taste_label ?sensory_value WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_name ?texture_label ?sensory_value WHERE {
     ?i a :Ingredient ;
         skos:prefLabel ?ingredient_name ;
@@ -208,7 +219,8 @@ SELECT ?ingredient_name ?texture_label ?sensory_value WHERE {
         :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
         skos:prefLabel ?texture_label .
-} ORDER BY ?ingredient_name DESC(?sensory_value)
+}
+ORDER BY ?ingredient_name DESC(?sensory_value)
 ```
 
 </details>
@@ -219,6 +231,7 @@ SELECT ?ingredient_name ?texture_label ?sensory_value WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_name ?trigeminal_label ?sensory_value WHERE {
     ?i a :Ingredient ;
         skos:prefLabel ?ingredient_name ;
@@ -228,7 +241,8 @@ SELECT ?ingredient_name ?trigeminal_label ?sensory_value WHERE {
         :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
         skos:prefLabel ?trigeminal_label .
-} ORDER BY ?ingredient_name DESC(?sensory_value)
+}
+ORDER BY ?ingredient_name DESC(?sensory_value)
 ```
 
 </details>
@@ -241,13 +255,15 @@ SELECT ?ingredient_name ?trigeminal_label ?sensory_value WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_name (GROUP_CONCAT(DISTINCT ?functional_benefit; SEPARATOR = ", ") AS ?functional_benefits) WHERE {
     ?i a :Ingredient ;
-       skos:prefLabel ?ingredient_name ;
-       :hasFunctionalBenefit ?f .
+        skos:prefLabel ?ingredient_name ;
+        :hasFunctionalBenefit ?f .
     ?f a :FunctionalBenefit ;
-       skos:prefLabel ?functional_benefit .
-} GROUP BY ?ingredient_name ORDER BY ?ingredient_name
+        skos:prefLabel ?functional_benefit .
+}
+GROUP BY ?ingredient_name ORDER BY ?ingredient_name
 ```
 
 </details>
@@ -258,14 +274,16 @@ SELECT ?ingredient_name (GROUP_CONCAT(DISTINCT ?functional_benefit; SEPARATOR = 
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?functional_benefit ?functional_benefit_definition WHERE {
     ?i a :Ingredient ;
-       skos:prefLabel "Vodka"@en ;
-       :hasFunctionalBenefit ?f .
+        skos:prefLabel "Vodka"@en ;
+        :hasFunctionalBenefit ?f .
     ?f a :FunctionalBenefit ;
-       skos:prefLabel ?functional_benefit ;
-       skos:definition ?functional_benefit_definition .
-} ORDER BY ?functional_benefit
+        skos:prefLabel ?functional_benefit ;
+        skos:definition ?functional_benefit_definition .
+}
+ORDER BY ?functional_benefit
 ```
 
 </details>
@@ -276,12 +294,14 @@ SELECT ?functional_benefit ?functional_benefit_definition WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?functional_benefit (COUNT(DISTINCT ?i) AS ?ingredient_count) WHERE {
     ?i a :Ingredient ;
-       :hasFunctionalBenefit ?f .
+        :hasFunctionalBenefit ?f .
     ?f a :FunctionalBenefit ;
-       skos:prefLabel ?functional_benefit .
-} GROUP BY ?functional_benefit ORDER BY DESC(?ingredient_count) LIMIT 10
+        skos:prefLabel ?functional_benefit .
+}
+GROUP BY ?functional_benefit ORDER BY DESC(?ingredient_count) LIMIT 10
 ```
 
 </details>
@@ -294,13 +314,15 @@ SELECT ?functional_benefit (COUNT(DISTINCT ?i) AS ?ingredient_count) WHERE {
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_pairing ?key_ingredient ?related_ingredient ?foodpairing_match_score WHERE {
     ?p a :IngredientPairing ;
-       skos:prefLabel ?ingredient_pairing ;
-       :hasKeyIngredient/skos:prefLabel ?key_ingredient ;
-       :hasRelatedIngredient/skos:prefLabel ?related_ingredient ;
-       :matchScore ?foodpairing_match_score .
-} ORDER BY ?key_ingredient DESC(?foodpairing_match_score)
+        skos:prefLabel ?ingredient_pairing ;
+        :hasKeyIngredient/skos:prefLabel ?key_ingredient ;
+        :hasRelatedIngredient/skos:prefLabel ?related_ingredient ;
+        :matchScore ?foodpairing_match_score .
+}
+ORDER BY ?key_ingredient DESC(?foodpairing_match_score)
 ```
 
 </details>
@@ -311,17 +333,20 @@ SELECT ?ingredient_pairing ?key_ingredient ?related_ingredient ?foodpairing_matc
 ```sparql
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 SELECT ?ingredient_pairing ?related_ingredient ?foodpairing_match_score WHERE {
     ?p a :IngredientPairing ;
-       skos:prefLabel ?ingredient_pairing ;
-       :hasKeyIngredient/skos:prefLabel "Strawberry"@en ;
-       :hasRelatedIngredient/skos:prefLabel ?related_ingredient ;
-       :matchScore ?foodpairing_match_score .
-} ORDER BY DESC(?foodpairing_match_score) LIMIT 10
+        skos:prefLabel ?ingredient_pairing ;
+        :hasKeyIngredient/skos:prefLabel "Strawberry"@en ;
+        :hasRelatedIngredient/skos:prefLabel ?related_ingredient ;
+        :matchScore ?foodpairing_match_score .
+}
+ORDER BY DESC(?foodpairing_match_score) LIMIT 10
 ```
 
 </details>
 
 ## Wanna See More?
 
-In case you detect any problems or if you would like to have more information added to the Inspire KG, please do not hesitate [to create an issue](https://github.com/foodpairing/inspire_kg/issues), and we will shortly try to address it.
+In case you detect any problems or if you would like to have more information added to the Inspire KG, please do not
+hesitate [to create an issue](https://github.com/foodpairing/inspire_kg/issues), and we will shortly try to address it.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,327 @@
 # Inspire KG
 
+The Inspire KG is an RDF Knowledge Graph (KG) that contains the following:
+
+- Ingredient category taxonomy (139 categories, 4 layers);
+- 102 ingredients from the Foodpairing® DB;
+- Sensory information (aromas, tastes, textures, trigeminals);
+- Functional benefits;
+- Ingredient pairings.
+
+The Inspire KG is based on our own [Inspiration Tool](https://inspire.foodpairing.com/) for trying out ingredient
+combinations and contains a small subset of the knowledge that is available in
+our [in-house Enterprise KG](https://www.foodpairing.com/industry/research-fundamental/enterprise-wide-knowledge-graph/).
+
+## Relevant Resources
+
+The Inspire KG is freely available under [CC BY 4.0 DEED](LICENSE.md) from [here](inspire.ttl). Its specification is
+available [here](https://foodpairing.github.io/inspire_kg/), while the rest of this page presents some more technical
+use cases.
+
+## Use Cases
+
+Below are some illustrative use cases (in the form of SPARQL queries) demonstrating the practical use of the Inspire KG.
+
+### Ingredient Categories Taxonomy
+
 <details>
- <summary>Show example</summary>
+ <summary>Retrieve category information</summary>
 
-```java
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-```
-The printout is:
-```
-{
-   ?person rdf:type ex:Person . 
-   ?person ex:hasName ?name . 
+SELECT ?category_name ?category_definition ?broader_category_name WHERE {
+    ?c a :IngredientCategory ;
+        skos:prefLabel ?category_name ;
+        skos:definition ?category_definition .
+    OPTIONAL {
+        # top-level categories do not have a parent category
+        ?c skos:broader ?b .
+        ?b a :IngredientCategory ;
+            skos:prefLabel ?broader_category_name .
+    }
 }
+ORDER BY ?category_name
 ```
+
 </details>
+
+<details>
+ <summary>Count of child categories per parent category</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?parent_category_name (COUNT(DISTINCT ?c) AS ?child_count) WHERE {
+    ?p a :IngredientCategory ;
+        skos:prefLabel ?parent_category_name .
+    ?c a :IngredientCategory ;
+        skos:broader ?p .
+}
+GROUP BY ?parent_category_name ORDER BY ?parent_category_name
+```
+
+</details>
+
+### Food Ingredients
+
+<details>
+ <summary>Retrieve ingredient information</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?ingredient_name ?ingredient_definition ?ingredient_category_name ?wikidata_link WHERE {
+    ?i a :Ingredient ;
+        skos:prefLabel ?ingredient_name ;
+        skos:definition ?ingredient_definition ;
+        :hasIngredientCategory/skos:prefLabel ?ingredient_category_name ;
+        rdfs:seeAlso ?wikidata_link .
+} ORDER BY ?ingredient_name
+```
+
+</details>
+
+<details>
+ <summary>Retrieve ingredients belonging to specific categories</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?ingredient_name ?ingredient_definition ?ingredient_category_name WHERE {
+    ?i a :Ingredient ;
+       skos:prefLabel ?ingredient_name ;
+       skos:definition ?ingredient_definition ;
+       :hasIngredientCategory/skos:prefLabel ?ingredient_category_name .
+    VALUES ?ingredient_category_name { "Pome Fruits"@en "Tropical Fruits"@en }
+} ORDER BY ?ingredient_name
+```
+
+</details>
+
+<details>
+ <summary>Retrieve ingredients belonging to a master category</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?ingredient_name WHERE {
+    ?i a :Ingredient ;
+       skos:prefLabel ?ingredient_name ;
+       skos:definition ?ingredient_definition ;
+       :hasIngredientCategory ?c .
+    ?c a :IngredientCategory ;
+       skos:broader*/skos:prefLabel "Fruit Category"@en .
+} ORDER BY ?ingredient_name
+```
+
+</details>
+
+<details>
+ <summary>Federated query over Wikidata</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?ingredient_name ?water_footprint WHERE {
+    {
+        SELECT * WHERE {
+            ?i a :Ingredient ;
+               skos:prefLabel ?ingredient_name ;
+               rdfs:seeAlso ?wikidata .
+            BIND(URI(?wikidata) AS ?wikidataLink)
+        }
+    }
+    
+    # Retrieve water footprint per ingredient (wherever available) from Wikidata
+    SERVICE <https://query.wikidata.org/sparql> {
+        ?wikidataLink <http://www.wikidata.org/prop/direct/P6000> ?water_footprint .
+    }
+} ORDER BY ?ingredient_name ?water_footprint
+```
+
+</details>
+
+### Sensory Information
+
+<details>
+ <summary>Retrieve aroma information per ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_name ?aroma_label ?sensory_value ?aroma_intensity WHERE {
+    ?i a :Ingredient ;
+       skos:prefLabel ?ingredient_name ;
+       :hasAroma ?a .
+    ?a a :Aroma ;
+       :sensoryValue ?sensory_value ;
+       :hasSensoryDescriptor ?d .
+    ?d a :SensoryDescriptor ;
+       skos:prefLabel ?aroma_label ;
+       :aromaIntensity ?aroma_intensity .
+} ORDER BY ?ingredient_name DESC(?sensory_value)
+```
+
+</details>
+
+<details>
+ <summary>Retrieve taste information per ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_name ?taste_label ?sensory_value WHERE {
+    ?i a :Ingredient ;
+        skos:prefLabel ?ingredient_name ;
+        :hasTaste ?t .
+    ?t a :Taste ;
+        :sensoryValue ?sensory_value ;
+        :hasSensoryDescriptor ?d .
+    ?d a :SensoryDescriptor ;
+        skos:prefLabel ?taste_label .
+} ORDER BY ?ingredient_name DESC(?sensory_value)
+```
+
+</details>
+
+<details>
+ <summary>Retrieve texture information per ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_name ?texture_label ?sensory_value WHERE {
+    ?i a :Ingredient ;
+        skos:prefLabel ?ingredient_name ;
+        :hasTexture ?t .
+    ?t a :Texture ;
+        :sensoryValue ?sensory_value ;
+        :hasSensoryDescriptor ?d .
+    ?d a :SensoryDescriptor ;
+        skos:prefLabel ?texture_label .
+} ORDER BY ?ingredient_name DESC(?sensory_value)
+```
+
+</details>
+
+<details>
+ <summary>Retrieve trigeminal taste information per ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_name ?trigeminal_label ?sensory_value WHERE {
+    ?i a :Ingredient ;
+        skos:prefLabel ?ingredient_name ;
+        :hasTrigeminal ?t .
+    ?t a :Trigeminal ;
+        :sensoryValue ?sensory_value ;
+        :hasSensoryDescriptor ?d .
+    ?d a :SensoryDescriptor ;
+        skos:prefLabel ?trigeminal_label .
+} ORDER BY ?ingredient_name DESC(?sensory_value)
+```
+
+</details>
+
+### Functional Benefits
+
+<details>
+ <summary>Retrieve functional benefits per ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_name (GROUP_CONCAT(DISTINCT ?functional_benefit; SEPARATOR = ", ") AS ?functional_benefits) WHERE {
+    ?i a :Ingredient ;
+       skos:prefLabel ?ingredient_name ;
+       :hasFunctionalBenefit ?f .
+    ?f a :FunctionalBenefit ;
+       skos:prefLabel ?functional_benefit .
+} GROUP BY ?ingredient_name ORDER BY ?ingredient_name
+```
+
+</details>
+
+<details>
+ <summary>Retrieve functional benefits of a specific ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?functional_benefit ?functional_benefit_definition WHERE {
+    ?i a :Ingredient ;
+       skos:prefLabel "Vodka"@en ;
+       :hasFunctionalBenefit ?f .
+    ?f a :FunctionalBenefit ;
+       skos:prefLabel ?functional_benefit ;
+       skos:definition ?functional_benefit_definition .
+} ORDER BY ?functional_benefit
+```
+
+</details>
+
+<details>
+ <summary>Retrieve the most popular functional benefits</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?functional_benefit (COUNT(DISTINCT ?i) AS ?ingredient_count) WHERE {
+    ?i a :Ingredient ;
+       :hasFunctionalBenefit ?f .
+    ?f a :FunctionalBenefit ;
+       skos:prefLabel ?functional_benefit .
+} GROUP BY ?functional_benefit ORDER BY DESC(?ingredient_count) LIMIT 10
+```
+
+</details>
+
+### Ingredient Pairings
+
+<details>
+ <summary>Retrieve ingredient pairing information</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_pairing ?key_ingredient ?related_ingredient ?foodpairing_match_score WHERE {
+    ?p a :IngredientPairing ;
+       skos:prefLabel ?ingredient_pairing ;
+       :hasKeyIngredient/skos:prefLabel ?key_ingredient ;
+       :hasRelatedIngredient/skos:prefLabel ?related_ingredient ;
+       :matchScore ?foodpairing_match_score .
+} ORDER BY ?key_ingredient DESC(?foodpairing_match_score)
+```
+
+</details>
+
+<details>
+ <summary>Best matchings for a specific ingredient</summary>
+
+```sparql
+PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+SELECT ?ingredient_pairing ?related_ingredient ?foodpairing_match_score WHERE {
+    ?p a :IngredientPairing ;
+       skos:prefLabel ?ingredient_pairing ;
+       :hasKeyIngredient/skos:prefLabel "Strawberry"@en ;
+       :hasRelatedIngredient/skos:prefLabel ?related_ingredient ;
+       :matchScore ?foodpairing_match_score .
+} ORDER BY DESC(?foodpairing_match_score) LIMIT 10
+```
+
+</details>
+
+## Wanna See More?
+
+In case you detect any problems or if you would like to have more information added to the Inspire KG, please do not hesitate [to create an issue](https://github.com/foodpairing/inspire_kg/issues), and we will shortly try to address it.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ ORDER BY ?ingredient_name ?water_footprint
 PREFIX : <https://w3id.org/foodpairing_inspire_kg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
-SELECT ?ingredient_name ?aroma_label ?sensory_value ?aroma_intensity WHERE {
+SELECT ?ingredient_name ?aroma_label ?sensory_value WHERE {
     ?i a :Ingredient ;
         skos:prefLabel ?ingredient_name ;
         :hasAroma ?a .
@@ -173,8 +173,7 @@ SELECT ?ingredient_name ?aroma_label ?sensory_value ?aroma_intensity WHERE {
         :sensoryValue ?sensory_value ;
         :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
-        skos:prefLabel ?aroma_label ;
-        :aromaIntensity ?aroma_intensity .
+        skos:prefLabel ?aroma_label .
 }
 ORDER BY ?ingredient_name DESC(?sensory_value)
 ```

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ SELECT ?ingredient_name ?texture_label ?sensory_value WHERE {
         skos:prefLabel ?ingredient_name ;
         :hasTexture ?t .
     ?t a :Texture ;
-        :sensoryValue ?sensory_value ;
+        :sensoryValue ?sensory_value ; # texture is true/false
         :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
         skos:prefLabel ?texture_label .
@@ -237,7 +237,7 @@ SELECT ?ingredient_name ?trigeminal_label ?sensory_value WHERE {
         skos:prefLabel ?ingredient_name ;
         :hasTrigeminal ?t .
     ?t a :Trigeminal ;
-        :sensoryValue ?sensory_value ;
+        :sensoryValue ?sensory_value ; # trigeminal is true/false
         :hasSensoryDescriptor ?d .
     ?d a :SensoryDescriptor ;
         skos:prefLabel ?trigeminal_label .

--- a/index.html
+++ b/index.html
@@ -233,10 +233,6 @@ The Inspire KG contains the following classes and properties.</span>
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     class="hlist">
    <li>
-      <a href="#https://w3id.org/foodpairing_inspire_kg#aromaIntensity"
-         title="https://w3id.org/foodpairing_inspire_kg#aromaIntensity">aroma intensity</a>
-   </li>
-   <li>
       <a href="#https://w3id.org/foodpairing_inspire_kg#matchScore"
          title="https://w3id.org/foodpairing_inspire_kg#matchScore">Foodpairing match score</a>
    </li>
@@ -2115,14 +2111,6 @@ This section provides details for each class and property defined by the Inspire
          <span class="markdown">A sensory descriptor is a label used to describe a specific sensory property of an ingredient. We differentiate between 4 types: (a) Aroma descriptors contain properties like 'almond', 'cherry' and 'mustard'; (b) Texture descriptors contain properties like 'crunchy', 'hard' and 'gooey'; (c) Taste descriptors contain the five basic tastes 'salt', 'sour', 'sweet', 'bitter', and 'umami' and three additional descriptors 'fatty' (or 'oleogustus'), 'astringent', and 'pungent'; (d) Trigeminal taste descriptors contain taste sensations 'astringent', 'pungent', 'cooling' and 'tingling'.</span>
       </div>
       <dl class="description">
-         <dt>is in domain of</dt>
-         <dd>
-            <a href="#https://w3id.org/foodpairing_inspire_kg#aromaIntensity"
-               title="https://w3id.org/foodpairing_inspire_kg#aromaIntensity">aroma intensity</a>
-            <sup class="type-dp" title="data property">dp</sup>, <a href="#https://w3id.org/foodpairing_inspire_kg#hasAromaType"
-               title="https://w3id.org/foodpairing_inspire_kg#hasAromaType">has aroma type</a>
-            <sup class="type-op" title="object property">op</sup>
-         </dd>
          <dt>is in range of</dt>
          <dd>
             <a href="#https://w3id.org/foodpairing_inspire_kg#hasSensoryDescriptor"
@@ -2646,10 +2634,6 @@ This section provides details for each class and property defined by the Inspire
    <h3 id="dataproperties-headline" class="list">Data Properties</h3>
    <ul class="hlist">
       <li>
-         <a href="#https://w3id.org/foodpairing_inspire_kg#aromaIntensity"
-            title="https://w3id.org/foodpairing_inspire_kg#aromaIntensity">aroma intensity</a>
-      </li>
-      <li>
          <a href="#https://w3id.org/foodpairing_inspire_kg#matchScore"
             title="https://w3id.org/foodpairing_inspire_kg#matchScore">Foodpairing match score</a>
       </li>
@@ -2658,33 +2642,6 @@ This section provides details for each class and property defined by the Inspire
             title="https://w3id.org/foodpairing_inspire_kg#sensoryValue">sensory value</a>
       </li>
    </ul>
-   <div class="entity" id="https://w3id.org/foodpairing_inspire_kg#aromaIntensity">
-      <h3>aroma intensity<sup class="type-dp" title="data property">dp</sup>
-         <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#dataproperties">Data Property ToC</a>
-         </span>
-      </h3>
-      <p>
-         <strong>IRI:</strong> https://w3id.org/foodpairing_inspire_kg#aromaIntensity</p>
-      <div class="comment">
-         <span class="markdown">Expresses how strongly a certain aroma is perceived by a person, based on Foodpairing benchmarking.</span>
-      </div>
-      <div class="description">
-         <dl>
-            <dt>has domain</dt>
-            <dd>
-               <a href="#https://w3id.org/foodpairing_inspire_kg#SensoryDescriptor"
-                  title="https://w3id.org/foodpairing_inspire_kg#SensoryDescriptor">Sensory Descriptor</a>
-               <sup class="type-c" title="class">c</sup>
-            </dd>
-            <dt>has range</dt>
-            <dd>
-               <a href="http://www.w3.org/2001/XMLSchema#double"
-                  target="_blank"
-                  title="http://www.w3.org/2001/XMLSchema#double">double</a>
-            </dd>
-         </dl>
-      </div>
-   </div>
    <div class="entity" id="https://w3id.org/foodpairing_inspire_kg#matchScore">
       <h3>Foodpairing match score<sup class="type-dp" title="data property">dp</sup>
          <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#dataproperties">Data Property ToC</a>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@ $(function(){
 <!--INTRODUCTION SECTION-->
    <div id="introduction"><h2 id="intro" class="list">Introduction <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <span class="markdown">
-   The Inspire Knowledge Graph contains: (a) 102 food ingredients, (b) a 4-layer taxonomy of 150 ingredient categories, (c) sensory information for the ingredients (aromas, tastes, textures, trigeminals), (d) functional benefits of ingredients, (e) ingredient pairings.
+   The Inspire Knowledge Graph contains: (a) 102 food ingredients, (b) a 4-layer taxonomy of 139 ingredient categories, (c) sensory information for the ingredients (aromas, tastes, textures, trigeminals), (d) functional benefits of ingredients, (e) ingredient pairings.
 </span>
 
 

--- a/inspire.ttl
+++ b/inspire.ttl
@@ -211,16 +211,25 @@
         :hasRelatedIngredient  :000886 ;
         :matchScore            "0.267857134342194"^^xsd:double .
 
-:meaty_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "meaty_aroma"@en ;
-        :aromaIntensity  "10.5"^^xsd:double ;
-        :hasAromaType    :animal .
+:meaty_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "meaty_aroma"@en ;
+        :hasAromaType   :animal .
+
+:7a3ceda1-5763-4edc-a6e7-64a38ce976dd
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :orange_aroma ;
+        :sensoryValue          "1.25"^^xsd:double .
 
 :000148-006471  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mango with Carrot pairing" ;
         :hasKeyIngredient      :000148 ;
         :hasRelatedIngredient  :006471 ;
         :matchScore            "0.15625"^^xsd:double .
+
+:14e002f9-32e6-44ae-b379-0e20971e7609
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
 
 :000791-005622  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Scallop Saint Jacques pairing" ;
@@ -301,6 +310,11 @@
         :hasKeyIngredient      :000791 ;
         :hasRelatedIngredient  :000413 ;
         :matchScore            "0.0196078438311815"^^xsd:double .
+
+:ddf6bb9f-f84a-4858-9b46-bd10c8406f68
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pungent_aroma ;
+        :sensoryValue          "1.05"^^xsd:double .
 
 :001448-000887  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with White Chocolate pairing" ;
@@ -434,11 +448,6 @@
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0175438597798347"^^xsd:double .
 
-:4c3e9632-dc7f-47d6-abe7-69492a801696
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.07500000000000001"^^xsd:double .
-
 :000014-000021  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Boiled Egg with Fish Sauce pairing" ;
         :hasKeyIngredient      :000014 ;
@@ -468,6 +477,11 @@
         :hasRelatedIngredient  :000865 ;
         :matchScore            "0.128617361187935"^^xsd:double .
 
+:ddfa9334-6132-47da-8db4-dbe409363fac
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :fatty_taste ;
+        :sensoryValue          "0.1"^^xsd:double .
+
 :005545-000475  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mussel with Pecan Nut pairing" ;
         :hasKeyIngredient      :005545 ;
@@ -491,13 +505,6 @@
         :hasKeyIngredient      :005569 ;
         :hasRelatedIngredient  :000149 ;
         :matchScore            "0.357142865657806"^^xsd:double .
-
-:aromaIntensity  rdf:type  owl:DatatypeProperty ;
-        rdfs:domain      :SensoryDescriptor ;
-        rdfs:range       xsd:double ;
-        rdfs:seeAlso     <https://www.foodpairing.com/industry/glossary/definition/aroma-intensity-comparison/> ;
-        skos:definition  "Expresses how strongly a certain aroma is perceived by a person, based on Foodpairing benchmarking."@en ;
-        skos:prefLabel   "aroma intensity"@en .
 
 :000105-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Green Bean with Veal pairing" ;
@@ -616,16 +623,21 @@
         :hasRelatedIngredient  :000472 ;
         :matchScore            "0.195121943950653"^^xsd:double .
 
-:80dd1d53-301f-4b33-ba3a-097286198f2a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.30000000000000004"^^xsd:double .
-
 :005509-000213  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Long-Grain Rice with Red Cabbage pairing" ;
         :hasKeyIngredient      :005509 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.161290317773819"^^xsd:double .
+
+:120419d8-b9c4-4bdb-9b12-e10de8f94282
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "1.0"^^xsd:double .
+
+:9a145baa-c7dd-4722-9d6b-1d1ab8d694f7
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :roasted_aroma ;
+        :sensoryValue          "0.17500000000000002"^^xsd:double .
 
 :000840-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "London Dry Gin with Avocado pairing" ;
@@ -668,11 +680,6 @@
         :hasKeyIngredient      :006002 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0212765950709581"^^xsd:double .
-
-:4a7ed97d-9b5f-45e8-9ebf-a538d84379ba
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :woody_aroma ;
-        :sensoryValue          "0.025"^^xsd:double .
 
 :000096-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chives with Oyster pairing" ;
@@ -732,10 +739,10 @@
         :hasRelatedIngredient  :000311 ;
         :matchScore            "0.0497777760028839"^^xsd:double .
 
-:40bf3cf0-baf2-4270-98aa-74ec77a1125d
+:f994e140-4a66-44b2-af9c-07ef974a2ff4
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :orange_aroma ;
-        :sensoryValue          "7.5"^^xsd:double .
+        :hasSensoryDescriptor  :cucumber_aroma ;
+        :sensoryValue          "1.65"^^xsd:double .
 
 :000031-000182  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemongrass with Celery pairing" ;
@@ -820,6 +827,11 @@
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.104961834847927"^^xsd:double .
 
+:580d66af-0452-4070-b56d-c8485b9d8782
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "2.8"^^xsd:double .
+
 :000213-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Calvados pairing" ;
         :hasKeyIngredient      :000213 ;
@@ -831,6 +843,11 @@
         :hasKeyIngredient      :000109 ;
         :hasRelatedIngredient  :000091 ;
         :matchScore            "0.182204678654671"^^xsd:double .
+
+:1396a469-bc10-4b80-a82a-54000632d68e
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "2.0"^^xsd:double .
 
 :006821-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Yellow Grapefruit pairing" ;
@@ -902,9 +919,9 @@
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q131480"^^xsd:anyURI ;
         skos:definition         "Camembert is a soft, creamy cheese known for its rich, earthy flavor and velvety texture."@en ;
         skos:prefLabel          "Camembert"@en ;
-        :hasAroma               :61d506e1-68d5-4426-9650-97fac890c52a , :b7c3541a-be23-482a-a7f2-47fbdf0ac3ff , :d28ef172-b2ea-42f2-81ca-57b9374b01a4 , :44fe8e25-091b-4f35-b89b-97c95b2e015f , :f3e84a3e-d9fb-44e4-9c71-e580680dc1f4 ;
+        :hasAroma               :fa8c5241-3f78-44f0-b2aa-356e41b64315 , :f39f0f84-2eb9-480f-88ad-2109da4b9ce5 , :309b6890-9614-4be1-bf89-781e276f5d4f , :04b682af-40b0-4cea-84a8-37c03d58b181 , :9029fe44-e4e8-4c73-a97f-3c71aac0c2e8 ;
         :hasIngredientCategory  :icat:000059 ;
-        :hasTexture             :dcaa1e77-1f23-4972-be54-aec6490dbf25 , :d8fa9174-05ce-4026-b0e5-5b769d33fe5d .
+        :hasTexture             :bdf71b20-c2b3-4ea6-9f91-56ac5a5ce6aa , :29012ec3-3d06-400a-a695-44806efbfdf7 .
 
 :005545-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mussel with Cheddar pairing" ;
@@ -996,6 +1013,11 @@
         :hasRelatedIngredient  :005545 ;
         :matchScore            "0.200000002980232"^^xsd:double .
 
+:e74f673c-f3dc-43bd-9a0e-34afe1330797
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :creamy_texture ;
+        :sensoryValue          true .
+
 :000136-000306  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Atlantic Salmon pairing" ;
         :hasKeyIngredient      :000136 ;
@@ -1085,11 +1107,6 @@
         :hasRelatedIngredient  :000151 ;
         :matchScore            "0.223454833030701"^^xsd:double .
 
-:7730b241-361d-4f21-a584-d60f14894458
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :umami_taste ;
-        :sensoryValue          "0.3"^^xsd:double .
-
 :005569-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pear with Gruyère pairing" ;
         :hasKeyIngredient      :005569 ;
@@ -1144,11 +1161,6 @@
         :hasRelatedIngredient  :003143 ;
         :matchScore            "-4.65000009536743"^^xsd:double .
 
-:fd3467b4-22a2-4e4e-a005-d89ad3825408
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "5.25"^^xsd:double .
-
 :000920-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Lime pairing" ;
         :hasKeyIngredient      :000920 ;
@@ -1159,9 +1171,9 @@
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q23374"^^xsd:anyURI ;
         skos:definition         "Spicy sausage made from ground pork and chili peppers, commonly used in Spanish and Mexican dishes."@en ;
         skos:prefLabel          "Chorizo"@en ;
-        :hasAroma               :c40cc390-9616-4dec-a0db-efb981592748 , :6bc1e34f-7a40-450c-8236-fca64e3cf245 , :d029c774-68b9-40a0-bd7d-e980edcbbfe1 , :32e03a99-5ca6-4917-bd8b-d97fa0daa455 , :ab667da2-27ad-48bf-803d-2b4632dbdd98 , :4a7ed97d-9b5f-45e8-9ebf-a538d84379ba ;
+        :hasAroma               :586ded93-8f43-410e-98c7-8ab719a6c760 , :62cc403e-eeb6-444f-972d-b2a47b9c2681 , :a9bd1fa8-477d-4b30-9e4e-dff95b690a71 , :1f5503f5-571f-43da-ba71-73399bfd10a2 , :0f8ffd5e-f69d-4f5a-96c3-2052dbd9495b , :16da755a-9e6e-4f95-8a3d-f15a8c22b8a4 ;
         :hasIngredientCategory  :icat:000104 ;
-        :hasTaste               :1b2adaf6-0f22-4c85-8879-c096f52c2c72 .
+        :hasTaste               :ddfa9334-6132-47da-8db4-dbe409363fac .
 
 :000083-001394  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Popcorn pairing" ;
@@ -1181,21 +1193,21 @@
         :hasRelatedIngredient  :000215 ;
         :matchScore            "0.126213595271111"^^xsd:double .
 
+:a0e2e1c6-37cc-44ad-832c-371a24119cbf
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.5"^^xsd:double .
+
 :001696-000031  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grape with Lemongrass pairing" ;
         :hasKeyIngredient      :001696 ;
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.256756752729416"^^xsd:double .
 
-:bb501236-8746-4099-9b30-a6e982f43d28
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
-
-:82348c43-7305-4d28-aec7-56dadb1266e5
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
+:9d932e97-1f6f-4823-b4a4-35080329f7f1
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :floral_aroma ;
+        :sensoryValue          "1.05"^^xsd:double .
 
 :001394-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Blueberry pairing" ;
@@ -1215,6 +1227,11 @@
         :hasRelatedIngredient  :000252 ;
         :matchScore            "0.0556483045220375"^^xsd:double .
 
+:f9607212-bdb1-40d5-bd8a-c5b81a0a1c64
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "2.6999999999999997"^^xsd:double .
+
 :000148-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mango with Armagnac pairing" ;
         :hasKeyIngredient      :000148 ;
@@ -1226,11 +1243,6 @@
         :hasKeyIngredient      :007170 ;
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.00990098994225264"^^xsd:double .
-
-:0db3c3a5-7150-4d1a-be4c-da25b6400bf9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :apple_aroma ;
-        :sensoryValue          "0.26"^^xsd:double .
 
 :000109-000017  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Tomato pairing" ;
@@ -1423,6 +1435,11 @@
         skos:definition  "Encompasses vegetables where the seeds or seed pods are the primary edible part, such as beans, peas, or corn."@en ;
         skos:prefLabel   "Seed Vegetables"@en .
 
+:385def65-9d6c-47d5-9256-6b4b69771ef3
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "0.2"^^xsd:double .
+
 :001755-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Spinach pairing" ;
         :hasKeyIngredient      :001755 ;
@@ -1464,11 +1481,6 @@
         :hasKeyIngredient      :005754 ;
         :hasRelatedIngredient  :000117 ;
         :matchScore            "0.001641791081056"^^xsd:double .
-
-:44fe8e25-091b-4f35-b89b-97c95b2e015f
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pungent_aroma ;
-        :sensoryValue          "3.15"^^xsd:double .
 
 :000452-000013  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Full-fat Yogurt pairing" ;
@@ -1524,6 +1536,11 @@
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.103249318897724"^^xsd:double .
 
+:c9d4266d-48f3-4cbb-ab90-a465772d5c57
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "7.2"^^xsd:double .
+
 :001394-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Brewed Coffee pairing" ;
         :hasKeyIngredient      :001394 ;
@@ -1578,11 +1595,6 @@
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.0357142873108387"^^xsd:double .
 
-:9e531552-3900-4d7b-959b-4d307316c840
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000472-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Blueberry pairing" ;
         :hasKeyIngredient      :000472 ;
@@ -1623,11 +1635,11 @@
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q10978"^^xsd:anyURI ;
         skos:definition         "Grapes are small, round fruits with a sweet and juicy flavor, commonly eaten fresh or used for making wine."@en ;
         skos:prefLabel          "Grape"@en ;
-        :hasAroma               :b1e130dd-2413-48f2-9edf-43d598c35510 , :c9e1737b-27f7-4256-be74-6a8f90a940d5 , :33d89b13-f928-4741-b337-73f0ae499543 , :28a6c8e1-a8eb-4064-90b7-fc0515f6250c ;
+        :hasAroma               :c87cc514-f4ed-4a4b-9083-c7a059dd84fc , :4ef3c7a8-516b-4f79-b6a1-9df42dd54800 , :c21418e8-1d58-4d6e-a3a6-70e5fd4e16e6 , :bd9dbe51-8cb0-4271-8be7-15c7215ac58a ;
         :hasFunctionalBenefit   :Ageing , :Weight-loss , :Prebiotic , :Antibacterial , :Cardiovascular , :Bone , :Stress , :Brain , :Antioxidant , :Energy , :Diabetic , :Weight-gain , :Digestion , :Minerals , :Probiotic , :Vitamins , :Nervous-system , :Immunity ;
         :hasIngredientCategory  :icat:000088 ;
-        :hasTaste               :8a5e16b2-1d59-4379-a3fd-3533f53b2b4d ;
-        :hasTexture             :f4cc5c03-b7f3-49fd-88a5-dcdc8968385f .
+        :hasTaste               :51ff66d8-ddfd-4fc6-bd51-87ecc18c8c45 ;
+        :hasTexture             :28a0fa55-737a-4924-9ea6-d326d7e362af .
 
 :000110-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Leek with Brussels Sprouts pairing" ;
@@ -1665,6 +1677,11 @@
         :hasRelatedIngredient  :000104 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
 
+:ea879404-8324-4392-bf95-8bda58db1f93
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :potato_aroma ;
+        :sensoryValue          "4.5"^^xsd:double .
+
 :003143-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Basil Leaf pairing" ;
         :hasKeyIngredient      :003143 ;
@@ -1682,11 +1699,6 @@
         :hasKeyIngredient      :005942 ;
         :hasRelatedIngredient  :000096 ;
         :matchScore            "0.0746705681085587"^^xsd:double .
-
-:ef7e9b99-f0ee-43e2-a6cb-0b0b40d88fff
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "6.0"^^xsd:double .
 
 :000021-005569  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Pear pairing" ;
@@ -1758,10 +1770,10 @@
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13317"^^xsd:anyURI ;
         skos:definition         "Dairy product with a high fat content, providing a creamy texture and rich flavor."@en ;
         skos:prefLabel          "Full-fat Yogurt"@en ;
-        :hasAroma               :66b4ffac-5284-4701-9a85-5f3a2fa8220b , :2a930cb6-13e1-4f7f-bf51-7b21afe42d04 , :4bd8e88e-9d3b-4e61-89a9-714b51119615 , :1f73c26e-f642-4b9f-b440-c24eb2f32d33 ;
+        :hasAroma               :75ec6f4f-dba2-429f-b17e-11005652a6e2 , :c3a666a5-3014-45e3-a416-400360266306 , :f896f07c-e6a3-4a4d-8d5e-6be6b80d991c , :5a926eaa-71fb-44bb-965f-50ab96648787 ;
         :hasFunctionalBenefit   :Immunity , :Diabetic , :Stress , :Sleep , :Bone , :Vitamins , :Weight-loss , :Weight-gain , :Minerals , :Antioxidant , :Antibacterial , :Digestion , :Prebiotic , :Cardiovascular , :Energy ;
         :hasIngredientCategory  :icat:000052 ;
-        :hasTaste               :141e8465-5e9d-469b-b59b-0fa7614658fe , :2f727353-bf54-4ae4-ab03-992d39cc3fd7 .
+        :hasTaste               :113fc837-e11c-4903-a0fb-e1aa9911b1f2 , :87b8e806-dbf2-4836-a892-85cd384cb417 .
 
 :007170-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Veal pairing" ;
@@ -1845,11 +1857,6 @@
         :hasKeyIngredient      :000101 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0799999982118607"^^xsd:double .
-
-:92384141-ff9e-4b2a-8ce0-5cbf39226085
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "3.2"^^xsd:double .
 
 :001755-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Gruyère pairing" ;
@@ -2007,16 +2014,16 @@
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.318181812763214"^^xsd:double .
 
-:6bc1e34f-7a40-450c-8236-fca64e3cf245
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :smoky_aroma ;
-        :sensoryValue          "0.44999999999999996"^^xsd:double .
-
 :000993-000182  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tabasco with Celery pairing" ;
         :hasKeyIngredient      :000993 ;
         :hasRelatedIngredient  :000182 ;
         :matchScore            "0.009022556245327"^^xsd:double .
+
+:a0298dd4-28f1-4fb1-8ff8-b090ec8a5ca2
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "9.0"^^xsd:double .
 
 :005942-001755  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Cava pairing" ;
@@ -2066,11 +2073,6 @@
         :hasRelatedIngredient  :000840 ;
         :matchScore            "0.800000011920929"^^xsd:double .
 
-:aa4a3a2d-1d71-4e24-a051-1d4ce719c192
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :roasted_aroma ;
-        :sensoryValue          "0.17500000000000002"^^xsd:double .
-
 :000306-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Raspberry pairing" ;
         :hasKeyIngredient      :000306 ;
@@ -2119,6 +2121,11 @@
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.259999990463257"^^xsd:double .
 
+:bd9dbe51-8cb0-4271-8be7-15c7215ac58a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :grape_aroma ;
+        :sensoryValue          "1.3499999999999999"^^xsd:double .
+
 :007170-000787  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Vanilla 'Bourbon' pairing" ;
         :hasKeyIngredient      :007170 ;
@@ -2149,11 +2156,6 @@
         :hasRelatedIngredient  :000787 ;
         :matchScore            "0.00580152682960033"^^xsd:double .
 
-:b96a62cb-05b8-45fa-b841-8bbe63555bd8
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :honey_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000161-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with Plum pairing" ;
         :hasKeyIngredient      :000161 ;
@@ -2164,10 +2166,10 @@
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q169"^^xsd:anyURI ;
         skos:definition         "Mangoes are tropical fruits with a sweet, juicy flesh and a distinctive flavor, commonly eaten fresh or used in salsas and desserts."@en ;
         skos:prefLabel          "Mango"@en ;
-        :hasAroma               :5b0c47ee-c83b-4d66-ae81-8834cf60c7e7 , :bada12ff-e2fa-436c-82c8-defb2a34f2e4 , :1c713b2f-c728-4c4d-83a1-f4576eb29982 , :29c810f4-12c2-45f9-800f-9bd74f57f057 ;
+        :hasAroma               :19152386-86d5-419f-bd3f-9e9a8cce9f74 , :7216dd0c-b309-45b8-9e2a-6d3a6e0196dc , :fc77f3bd-49e0-4273-9111-95c5d3e6da5e , :654a3f39-996f-42f8-998f-9eb0b459c1ab ;
         :hasFunctionalBenefit   :Diabetic , :Digestion , :Stress , :Brain , :Energy , :Probiotic , :Weight-loss , :Minerals , :Bone , :Cardiovascular , :Weight-gain , :Antioxidant , :Immunity , :Prebiotic ;
         :hasIngredientCategory  :icat:000093 ;
-        :hasTaste               :ddb6e911-03af-419f-a407-6f4e01495b49 , :ef6a4089-bcac-4b4f-8be1-668cd55a7b9e .
+        :hasTaste               :08909c24-572f-41fe-9af2-2641ab3dce48 , :f1073d4e-da3d-4939-8b1e-b6d1df90d5b1 .
 
 :000887-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Champignon Mushroom pairing" ;
@@ -2215,11 +2217,6 @@
         :hasKeyIngredient      :000515 ;
         :hasRelatedIngredient  :000046 ;
         :matchScore            "0.20666666328907"^^xsd:double .
-
-:024415ab-2085-4f93-a012-951348ff8353
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :berry_aroma ;
-        :sensoryValue          "19.0"^^xsd:double .
 
 :hasFlavour  rdf:type    owl:ObjectProperty ;
         rdfs:domain      :Ingredient ;
@@ -2311,10 +2308,10 @@
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.253968268632889"^^xsd:double .
 
-:c441da0c-0811-4671-a2b4-956745958d25
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "0.2"^^xsd:double .
+:46ec56d7-e8d0-4db9-8945-d52695cabeb3
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
 
 :000096-000031  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chives with Lemongrass pairing" ;
@@ -2351,11 +2348,6 @@
         :hasKeyIngredient      :000151 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.435267865657806"^^xsd:double .
-
-:582306d4-06bf-49db-994d-6d347c566e56
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :woody_aroma ;
-        :sensoryValue          "0.05"^^xsd:double .
 
 :000472-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Hamburger pairing" ;
@@ -2446,11 +2438,6 @@
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.051446944475174"^^xsd:double .
 
-:6c7881d8-51c9-41d4-98c0-a96320534d8d
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :honey_aroma ;
-        :sensoryValue          "15.0"^^xsd:double .
-
 :000055-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Mustard pairing" ;
         :hasKeyIngredient      :000055 ;
@@ -2469,6 +2456,11 @@
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.0341538451611996"^^xsd:double .
 
+:fa8c5241-3f78-44f0-b2aa-356e41b64315
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "0.375"^^xsd:double .
+
 :000213-000082  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Belgian Endive pairing" ;
         :hasKeyIngredient      :000213 ;
@@ -2480,11 +2472,6 @@
         :hasKeyIngredient      :000151 ;
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.381919652223587"^^xsd:double .
-
-:f0f481a3-6346-48c2-a6f9-1603ad1c96ce
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "1.7000000000000002"^^xsd:double .
 
 :003246-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cow Mozzarella with Emmentaler pairing" ;
@@ -2752,11 +2739,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.0399999991059303"^^xsd:double .
 
-:999b740c-eace-4761-8e72-c7c4511b6b26
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :crunchy_texture ;
-        :sensoryValue          true .
-
 :000136-000149  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Banana pairing" ;
         :hasKeyIngredient      :000136 ;
@@ -2793,6 +2775,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000144 ;
         :matchScore            "0.113333337008953"^^xsd:double .
 
+:f9a950ce-f802-43fb-8d8d-e7e12392867e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :tropical_aroma ;
+        :sensoryValue          "7.5"^^xsd:double .
+
 :000311-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Basil Leaf pairing" ;
         :hasKeyIngredient      :000311 ;
@@ -2816,14 +2803,19 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.249169439077377"^^xsd:double .
 
+:4a13c530-73f9-4f53-96d7-1e9f78b85d0a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :mushroom_aroma ;
+        :sensoryValue          "0.5"^^xsd:double .
+
 :006821  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q277628"^^xsd:anyURI ;
         skos:definition         "Rich and bittersweet chocolate made from cocoa solids and sugar, known for its complex flavor profiles."@en ;
         skos:prefLabel          "Dark Chocolate"@en ;
-        :hasAroma               :95b9f01e-4954-46d8-8e1f-4beabc8c95ef , :b8b32248-c148-4cd0-aa9c-65685a9672ad , :003d4c0f-70d3-43a5-bda3-a6ed12e725c0 , :17f3b4e7-dadd-4ef2-a3c3-1590c4cbfeeb , :b36553aa-db4b-4126-87a9-400ab244ac4d , :db0599c1-05ac-4643-ae3e-c41137e8f87a ;
+        :hasAroma               :9985c9a2-863d-42ba-af8e-1c1b5db9bc6b , :45e02b7a-c4b1-4b53-b003-551a3e4b06be , :1c339b73-3a3c-4644-be98-897cb5426648 , :e76a6d57-2cf5-457d-a65a-fd38da4d2817 , :757a5690-02a6-48dc-b028-e1db38424d88 , :1193764b-7cae-47d8-a53a-358e27021cb2 ;
         :hasIngredientCategory  :icat:000004 ;
-        :hasTaste               :42e0395c-65fc-4d64-8f2e-6e06b715ddb1 ;
-        :hasTexture             :6dc34eab-e17e-48ee-951c-12211962adf5 , :944ae229-5c90-4e57-8804-573c25a1fad9 .
+        :hasTaste               :5d74bf5a-45c9-4a26-b970-7eb939c554b6 ;
+        :hasTexture             :2aa6f95c-f733-43fe-8c47-8a421e5030b3 , :18878256-682c-4a29-88ad-f760187b5385 .
 
 :003290-000787  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Vanilla 'Bourbon' pairing" ;
@@ -2915,11 +2907,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000096 ;
         :matchScore            "0.00321543402969837"^^xsd:double .
 
-:2f727353-bf54-4ae4-ab03-992d39cc3fd7
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "0.2"^^xsd:double .
-
 :000017-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tomato with Sweet Vermouth pairing" ;
         :hasKeyIngredient      :000017 ;
@@ -2950,11 +2937,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.0256410259753466"^^xsd:double .
 
-:4c53b07d-8fbc-4eba-a449-c32f53ee5fb2
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "0.15000000000000002"^^xsd:double .
-
 :005622-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Scallop Saint Jacques with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :005622 ;
@@ -2972,11 +2954,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000357 ;
         :hasRelatedIngredient  :000876 ;
         :matchScore            "0.0153846153989434"^^xsd:double .
-
-:9b2097ba-7a6c-48ac-8152-5d2895e94d3e
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :fatty_taste ;
-        :sensoryValue          "3.0"^^xsd:double .
 
 :000452-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Red Bell Pepper pairing" ;
@@ -3013,6 +2990,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005760 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.165714278817177"^^xsd:double .
+
+:511f32e1-7f08-4099-b689-268c3ce6e0d5
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :salt_taste ;
+        :sensoryValue          "0.2"^^xsd:double .
 
 :000873-005545  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Mussel pairing" ;
@@ -3051,9 +3033,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.116009280085564"^^xsd:double .
 
 :potato_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "potato_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "potato_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000213-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Mustard pairing" ;
@@ -3101,7 +3082,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q932214"^^xsd:anyURI ;
         skos:definition         "Emmentaler is a Swiss cheese with a nutty flavor and distinctive holes, commonly used in cooking and sandwiches."@en ;
         skos:prefLabel          "Emmentaler"@en ;
-        :hasAroma               :069726b6-c9fa-40d9-b5fb-de388d60525e , :703efc1e-5e4c-4811-a4f7-6b8c5ffd7174 , :7329d88c-5160-4d4e-b50a-5c34b094d9e1 ;
+        :hasAroma               :a903665b-884b-472d-b028-830684f21644 , :5707687a-98bc-4f7d-b8c5-a8513636ccba , :a357ef15-2e67-4e77-b208-62e0f197454a ;
         :hasIngredientCategory  :icat:000055 .
 
 :000090-000109  rdf:type       :IngredientPairing ;
@@ -3110,10 +3091,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.0681198909878731"^^xsd:double .
 
-:lemon_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "lemon_aroma"@en ;
-        :aromaIntensity  "1.25"^^xsd:double ;
-        :hasAromaType    :citrus .
+:lemon_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "lemon_aroma"@en ;
+        :hasAromaType   :citrus .
 
 :000136-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Plum pairing" ;
@@ -3199,6 +3179,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.131832793354988"^^xsd:double .
 
+:91a7760a-9edf-4847-b3f5-4ba51e4434a8
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :salt_taste ;
+        :sensoryValue          "4.0"^^xsd:double .
+
 :005569-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pear with Raspberry pairing" ;
         :hasKeyIngredient      :005569 ;
@@ -3251,16 +3236,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q106446932"^^xsd:anyURI ;
         skos:definition         "A vibrant red vegetable with a sweet and crunchy texture, used in salads, roasting, and cooking."@en ;
         skos:prefLabel          "Red Bell Pepper"@en ;
-        :hasAroma               :2a885fc3-6db2-479c-accc-68fb423dd9a1 , :f0f481a3-6346-48c2-a6f9-1603ad1c96ce ;
+        :hasAroma               :0e6fafb5-5926-4205-85a2-99ae9f5325d5 , :12ac9ead-44d4-4ded-9043-e49d1875499d ;
         :hasFunctionalBenefit   :Antioxidant ;
         :hasIngredientCategory  :icat:000129 ;
-        :hasTaste               :f3a443d1-1ac3-474a-ae8f-2d8e15158137 ;
-        :hasTexture             :c533bb50-907e-4ab4-9764-27c0b3e23902 .
-
-:e7f1c861-697e-4e11-b3be-d37ef59d0006
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fig_aroma ;
-        :sensoryValue          "0.7000000000000001"^^xsd:double .
+        :hasTaste               :544ad1a6-518f-455e-878b-45dd7431d85c ;
+        :hasTexture             :36a991b2-c65f-4626-b64c-eab2a0012f2b .
 
 :000117-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Spinach pairing" ;
@@ -3310,11 +3290,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.222465753555298"^^xsd:double .
 
-:550b26fb-58c4-4516-8e47-2069f7144436
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "0.75"^^xsd:double .
-
 :005509-000149  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Long-Grain Rice with Banana pairing" ;
         :hasKeyIngredient      :005509 ;
@@ -3326,6 +3301,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005675 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.111811026930809"^^xsd:double .
+
+:a480df64-f7cd-498c-91b7-fbf019c51046
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :banana_aroma ;
+        :sensoryValue          "36.0"^^xsd:double .
 
 :000475-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pecan Nut with Milk pairing" ;
@@ -3453,21 +3433,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000151 ;
         :matchScore            "0.00666666682809591"^^xsd:double .
 
-:9a0ee21e-f192-4860-94fd-c34c9db6cede
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :007105-000030  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Ginger pairing" ;
         :hasKeyIngredient      :007105 ;
         :hasRelatedIngredient  :000030 ;
         :matchScore            "0.00199335557408631"^^xsd:double .
-
-:35fafdfc-61c3-4d8e-beff-a5b384cf7ace
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "2.55"^^xsd:double .
 
 :000109-000787  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Vanilla 'Bourbon' pairing" ;
@@ -3480,6 +3450,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000059 ;
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.400000005960464"^^xsd:double .
+
+:ce286a59-9fef-4eba-80b5-9a8ffc4c5c77
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :herbal_aroma ;
+        :sensoryValue          "0.14"^^xsd:double .
 
 :000938-000013  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Asparagus with Full-fat Yogurt pairing" ;
@@ -3509,7 +3484,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q104248689"^^xsd:anyURI ;
         skos:definition         "Edible fungi with a mild flavor and smooth texture, often used in cooking."@en ;
         skos:prefLabel          "Champignon Mushroom"@en ;
-        :hasAroma               :5b23b6a8-d9e1-42d0-9698-ecacf1ebdcdb , :bca8bd1e-928f-4a89-8bfa-83949e3d749b ;
+        :hasAroma               :db34b597-44cc-4047-8aca-7be133cceb23 , :ef0c7d6e-3f3d-41d2-b1e2-c692c5935c03 ;
         :hasFunctionalBenefit   :Immunity , :Probiotic , :Weight-loss , :Diabetic , :Cardiovascular , :Digestion , :Energy , :Weight-gain , :Brain , :Antioxidant , :Ageing , :Nervous-system , :Minerals , :Satiety , :Vitamins , :Prebiotic , :Bone ;
         :hasIngredientCategory  :icat:000131 .
 
@@ -3536,6 +3511,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000452 ;
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.00341463414952159"^^xsd:double .
+
+:a63ebb08-71f6-4553-abda-37b50309aa58
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :honey_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000090-000104  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Goat Cheese pairing" ;
@@ -3669,6 +3649,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :002530 ;
         :matchScore            "0.0724637657403946"^^xsd:double .
 
+:2b449a99-0a8f-46a4-9e8b-a84458638567
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :buttery_aroma ;
+        :sensoryValue          "0.45"^^xsd:double .
+
 :000472-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Jasmine Tea pairing" ;
         :hasKeyIngredient      :000472 ;
@@ -3722,11 +3707,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000072 ;
         :hasRelatedIngredient  :003246 ;
         :matchScore            "0.111111111938953"^^xsd:double .
-
-:2a885fc3-6db2-479c-accc-68fb423dd9a1
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :bell_pepper_aroma ;
-        :sensoryValue          "1.7999999999999998"^^xsd:double .
 
 :006002-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pasta with Plum pairing" ;
@@ -3860,11 +3840,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.734649121761322"^^xsd:double .
 
-:42e0395c-65fc-4d64-8f2e-6e06b715ddb1
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000515-003290  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster Mushroom with Brie pairing" ;
         :hasKeyIngredient      :000515 ;
@@ -3925,16 +3900,20 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.0347328260540962"^^xsd:double .
 
-:smoky_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "smoky_aroma"@en ;
-        :aromaIntensity  "15.0"^^xsd:double ;
-        :hasAromaType    :woody .
+:smoky_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "smoky_aroma"@en ;
+        :hasAromaType   :woody .
 
 :001959-005569  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grappa with Pear pairing" ;
         :hasKeyIngredient      :001959 ;
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.15384615957737"^^xsd:double .
+
+:70dc47e9-062e-4c16-8334-8b313449df98
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "0.625"^^xsd:double .
 
 :005754-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Hamburger with Brussels Sprouts pairing" ;
@@ -4013,6 +3992,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001218 ;
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.114285714924335"^^xsd:double .
+
+:b0d208ac-ba64-4689-970f-7e44babd991c
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "1.5"^^xsd:double .
 
 :000252-006002  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Potato with Pasta pairing" ;
@@ -4128,11 +4112,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
 
-:7e9ab118-ece5-4372-ab56-b254342faafe
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :herbal_aroma ;
-        :sensoryValue          "10.5"^^xsd:double .
-
 :000182-001008  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Celery with Milk Chocolate pairing" ;
         :hasKeyIngredient      :000182 ;
@@ -4149,11 +4128,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000787 ;
         :hasRelatedIngredient  :001959 ;
         :matchScore            "0.190839692950249"^^xsd:double .
-
-:2f24ecac-a557-4ed1-aa67-cb46db928fc0
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "3.75"^^xsd:double .
 
 :000920-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Turkey pairing" ;
@@ -4329,6 +4303,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.253164559602737"^^xsd:double .
 
+:52a81b04-5546-4739-800a-e39953357fbc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "1.875"^^xsd:double .
+
 :007105-000313  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Honey pairing" ;
         :hasKeyIngredient      :007105 ;
@@ -4364,11 +4343,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000040 ;
         :hasRelatedIngredient  :000252 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
-
-:e1eb78d9-e4aa-4690-91ca-ab1e463824b2
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "2.6999999999999997"^^xsd:double .
 
 :000161-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with Oyster Mushroom pairing" ;
@@ -4417,6 +4391,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000161 ;
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.194466590881348"^^xsd:double .
+
+:871902c4-131c-4a4f-967f-3388ab83d3b2
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000357-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Tequila Silver pairing" ;
@@ -4525,26 +4504,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.0318749994039536"^^xsd:double .
 
-:997e39a4-955d-4877-8c43-acb5872ec927
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :corn_aroma ;
-        :sensoryValue          "13.5"^^xsd:double .
-
-:c9e1737b-27f7-4256-be74-6a8f90a940d5
+:480589a9-da9c-4481-b23b-3e8ced5d2af3
         rdf:type               :Aroma ;
         :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "5.25"^^xsd:double .
-
-:003d4c0f-70d3-43a5-bda3-a6ed12e725c0
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.15000000000000002"^^xsd:double .
+        :sensoryValue          "2.8000000000000003"^^xsd:double .
 
 :005760  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q957434"^^xsd:anyURI ;
         skos:definition         "Veal is tender, pale-pink meat from young calves, prized for its delicate flavor and tenderness, commonly used in gourmet cuisine."@en ;
         skos:prefLabel          "Veal"@en ;
-        :hasAroma               :c37ee76c-8c40-4a46-9240-3609cd819b18 , :f77f2884-3836-49cd-a5a3-da7dc2c33827 ;
+        :hasAroma               :808a6e2a-dc72-4232-99a9-c01369d2380c , :8c6d86d1-e667-4324-982a-b05f90b6f722 ;
         :hasIngredientCategory  :icat:000107 .
 
 :006473-000072  rdf:type       :IngredientPairing ;
@@ -4570,6 +4539,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000213 ;
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.105263158679008"^^xsd:double .
+
+:9139bc78-fc31-464e-a3c3-e52712fc85ef
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :crunchy_texture ;
+        :sensoryValue          true .
 
 :000993-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tabasco with Blueberry pairing" ;
@@ -4625,16 +4599,30 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.160771697759628"^^xsd:double .
 
+:2623e44e-9c2b-4341-8aec-34337bdb40dd
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "2.6999999999999997"^^xsd:double .
+
+:8e8e6d59-d5a4-4d8b-a5bc-bbd264b9756f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :chocolate_aroma ;
+        :sensoryValue          "0.30000000000000004"^^xsd:double .
+
 :005842-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Hamburger pairing" ;
         :hasKeyIngredient      :005842 ;
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.258364319801331"^^xsd:double .
 
-:grape_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "grape_aroma"@en ;
-        :aromaIntensity  "4.5"^^xsd:double ;
-        :hasAromaType    :fruity .
+:7793d215-6349-4513-9fb6-73bd36897abc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :woody_aroma ;
+        :sensoryValue          "0.15"^^xsd:double .
+
+:grape_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "grape_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000452-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Sweet Vermouth pairing" ;
@@ -4678,11 +4666,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.601941764354706"^^xsd:double .
 
-:8aa273e3-b829-4cbf-8fa8-59f6ed1612dc
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.3"^^xsd:double .
-
 :000107-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Gruyère with Jasmine Tea pairing" ;
         :hasKeyIngredient      :000107 ;
@@ -4713,11 +4696,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006471 ;
         :matchScore            "0.263157904148102"^^xsd:double .
 
-:fcbefd61-0e20-4036-b54d-af26cea2be52
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :buttery_aroma ;
-        :sensoryValue          "0.6749999999999999"^^xsd:double .
-
 :000873-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Brussels Sprouts pairing" ;
         :hasKeyIngredient      :000873 ;
@@ -4736,26 +4714,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.224999994039536"^^xsd:double .
 
-:794219d8-6f09-4555-b5ae-3376ffd81194
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :strawberry_aroma ;
-        :sensoryValue          "18.4"^^xsd:double .
-
 :005942-000787  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Vanilla 'Bourbon' pairing" ;
         :hasKeyIngredient      :005942 ;
         :hasRelatedIngredient  :000787 ;
         :matchScore            "0.0102781848981977"^^xsd:double .
-
-:f14ec2fb-0cc0-4e2d-a347-a2a91fed5a31
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "9.0"^^xsd:double .
-
-:cddf7cf2-894d-4123-bbab-df6918499a4c
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "2.8"^^xsd:double .
 
 :000109-000133  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Strawberry pairing" ;
@@ -4816,11 +4779,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000040 ;
         :matchScore            "0.134706810116768"^^xsd:double .
 
-:d7006e22-cbc4-4a1d-bf96-4ddd67f7895b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :oat_flakes_cereal_aroma ;
-        :sensoryValue          "0.005"^^xsd:double .
-
 :000141-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Cheddar pairing" ;
         :hasKeyIngredient      :000141 ;
@@ -4875,11 +4833,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.105882354080677"^^xsd:double .
 
-:6147246a-d307-425b-a8fb-40ef58bfd16a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :coconut_aroma ;
-        :sensoryValue          "5.0"^^xsd:double .
-
 :000876-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Lemon pairing" ;
         :hasKeyIngredient      :000876 ;
@@ -4933,11 +4886,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000475 ;
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
-
-:c37ee76c-8c40-4a46-9240-3609cd819b18
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :roasted_aroma ;
-        :sensoryValue          "0.35000000000000003"^^xsd:double .
 
 :000078-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Turkey pairing" ;
@@ -5100,6 +5048,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.523809552192688"^^xsd:double .
 
+:82eb35f6-1fba-4054-b7a8-245e72aa3612
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :woody_aroma ;
+        :sensoryValue          "0.15"^^xsd:double .
+
 :001959-000865  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grappa with Sake pairing" ;
         :hasKeyIngredient      :001959 ;
@@ -5160,6 +5113,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000840 ;
         :matchScore            "0.230769231915474"^^xsd:double .
 
+:57492bce-5679-451a-ad74-4d7d51e97574
+        rdf:type               :Trigeminal ;
+        :hasSensoryDescriptor  :astringent_trigeminal_taste ;
+        :sensoryValue          true .
+
+:d74b7649-f29b-4a04-81ea-56b0dd4ecbad
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :violet_aroma ;
+        :sensoryValue          "0.5"^^xsd:double .
+
 :001218-005545  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Mussel pairing" ;
         :hasKeyIngredient      :001218 ;
@@ -5169,11 +5132,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
 :icat:000023  rdf:type   skos:Concept , :IngredientCategory ;
         skos:definition  "Encompasses various spices and spice blends used to add flavor and aroma to dishes."@en ;
         skos:prefLabel   "Spice Category"@en .
-
-:c686968f-b42b-4abe-ae2f-e9b0daeb8d9d
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "0.4"^^xsd:double .
 
 :000452-007109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Fig pairing" ;
@@ -5199,6 +5157,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.0422927103936672"^^xsd:double .
 
+:fb4edd76-cc68-4436-8705-7eb1a52d37df
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :orange_aroma ;
+        :sensoryValue          "3.75"^^xsd:double .
+
 :000123-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Rosemary with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :000123 ;
@@ -5221,9 +5184,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q193411"^^xsd:anyURI ;
         skos:definition         "Brie is a soft, creamy cheese known for its mild flavor and edible rind, commonly served as an appetizer."@en ;
         skos:prefLabel          "Brie"@en ;
-        :hasAroma               :cccdb869-9b0e-478f-b15a-c70212b0c67a , :d972e032-d4b7-481c-8587-df6caf8e28d1 , :af8d3edb-25c5-48a4-9da6-b3542f0faaca , :8c342af8-a06d-4277-99c2-305240a8daf7 ;
+        :hasAroma               :2b449a99-0a8f-46a4-9e8b-a84458638567 , :4a13c530-73f9-4f53-96d7-1e9f78b85d0a , :52a81b04-5546-4739-800a-e39953357fbc , :384da465-fd13-41c5-ae81-51cd8e8de14f ;
         :hasIngredientCategory  :icat:000059 ;
-        :hasTexture             :3c1024ba-4d1f-4854-af24-ddf19735ce3b , :c8ae8836-606f-4850-b185-a34335e55568 .
+        :hasTexture             :d45b6884-1b31-40fe-95cf-01d71b937fde , :03de19dd-4a2f-444e-9d9f-6bb841e6d359 .
 
 :000938-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Asparagus with Champignon Mushroom pairing" ;
@@ -5278,6 +5241,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001696 ;
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.060810811817646"^^xsd:double .
+
+:5d7d7690-9504-4d93-bcf6-10fb10647111
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :herbal_aroma ;
+        :sensoryValue          "10.5"^^xsd:double .
 
 :000865-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sake with Acacia Honey pairing" ;
@@ -5357,10 +5325,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.279720276594162"^^xsd:double .
 
-:6bb07799-bf53-42c5-965b-c0db4f784199
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :woody_aroma ;
-        :sensoryValue          "0.15"^^xsd:double .
+:cf8530e9-c68c-453e-9f35-b8d36a1e6c55
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
 
 :003143-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Brewed Coffee pairing" ;
@@ -5380,11 +5348,26 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.272727280855179"^^xsd:double .
 
+:db34b597-44cc-4047-8aca-7be133cceb23
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :earthy_aroma ;
+        :sensoryValue          "4.75"^^xsd:double .
+
 :000104-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Armagnac pairing" ;
         :hasKeyIngredient      :000104 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.0188679248094559"^^xsd:double .
+
+:205c5fdc-8095-4f0f-ad05-5c9b90d6d248
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fermented_aroma ;
+        :sensoryValue          "0.55"^^xsd:double .
+
+:daf14e93-fdf9-4c3b-b5b1-771e8b0441dd
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
 
 :000873-000840  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with London Dry Gin pairing" ;
@@ -5420,7 +5403,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q2746643"^^xsd:anyURI ;
         skos:definition         "Sweet, pear-shaped fruits with a unique texture and a mildly sweet flavor."@en ;
         skos:prefLabel          "Fig"@en ;
-        :hasAroma               :72b7b7f4-423c-4e6d-a65e-4c7b2a2e0074 , :e7f1c861-697e-4e11-b3be-d37ef59d0006 , :c856dfec-4e70-45c7-9d3e-172c6bc10994 ;
+        :hasAroma               :40d415d8-f6dd-459a-bfd3-ade5f8b6fe44 , :ce286a59-9fef-4eba-80b5-9a8ffc4c5c77 , :02825b62-c1c4-4058-b5e7-66c017a727da ;
         :hasFunctionalBenefit   :Digestion , :Stress , :Vitamins , :Sleep , :Weight-gain , :Minerals , :Energy , :Diabetic , :Brain , :Nervous-system , :Cardiovascular , :Immunity , :Bone , :Antioxidant , :Weight-loss ;
         :hasIngredientCategory  :icat:000093 .
 
@@ -5532,11 +5515,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000161 ;
         :matchScore            "0.0419847331941128"^^xsd:double .
 
-:5b0c47ee-c83b-4d66-ae81-8834cf60c7e7
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pineapple_aroma ;
-        :sensoryValue          "0.45"^^xsd:double .
-
 :005483-000993  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Tabasco pairing" ;
         :hasKeyIngredient      :005483 ;
@@ -5573,6 +5551,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.440438449382782"^^xsd:double .
 
+:16293514-d036-414e-9fc4-1331d1de00d1
+        rdf:type               :Trigeminal ;
+        :hasSensoryDescriptor  :astringent_trigeminal_taste ;
+        :sensoryValue          true .
+
 :000047-000215  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic with Beetroot pairing" ;
         :hasKeyIngredient      :000047 ;
@@ -5596,6 +5579,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005675 ;
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.111811026930809"^^xsd:double .
+
+:21f11285-44ac-4131-9f85-ed7d11049802
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "9.0"^^xsd:double .
 
 :000181-000021  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Fish Sauce pairing" ;
@@ -5789,11 +5777,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000413 ;
         :matchScore            "0.0228813551366329"^^xsd:double .
 
-:2096f30d-9642-43e6-b79d-07f4e2d66234
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :maple_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000117-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :000117 ;
@@ -5854,6 +5837,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005675 ;
         :matchScore            "0.0714285746216774"^^xsd:double .
 
+:e95fa90b-df48-466f-a8d7-c823cee62345
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :acidic_aroma ;
+        :sensoryValue          "0.7000000000000001"^^xsd:double .
+
 :003143-000355  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Sweet Corn pairing" ;
         :hasKeyIngredient      :003143 ;
@@ -5883,11 +5871,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005754 ;
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.158208951354027"^^xsd:double .
-
-:c0a46978-c624-4efc-865b-567c8dd50f34
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :roasted_aroma ;
-        :sensoryValue          "0.35000000000000003"^^xsd:double .
 
 :000141-005545  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Mussel pairing" ;
@@ -5926,9 +5909,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0133828995749354"^^xsd:double .
 
 :fermented_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "fermented_aroma"@en ;
-        :aromaIntensity  "5.5"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "fermented_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :005942-000133  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Strawberry pairing" ;
@@ -6097,6 +6079,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.204980254173279"^^xsd:double .
 
+:4925b116-96b0-4d03-96d4-522144a97d1d
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
+
 :001755-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Cantaloupe Melon pairing" ;
         :hasKeyIngredient      :001755 ;
@@ -6121,16 +6108,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000123 ;
         :matchScore            "0.181818187236786"^^xsd:double .
 
+:04b682af-40b0-4cea-84a8-37c03d58b181
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :buttery_aroma ;
+        :sensoryValue          "0.6749999999999999"^^xsd:double .
+
 :000082-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Belgian Endive with Baguette pairing" ;
         :hasKeyIngredient      :000082 ;
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.0799999982118607"^^xsd:double .
-
-:e02b799c-be09-4674-8d5c-ec7395d204c2
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
 
 :000355-000059  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Cauliflower pairing" ;
@@ -6318,6 +6305,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.150000005960464"^^xsd:double .
 
+:10fe6660-d4fe-4abf-9dd1-6b24022905df
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :ethanol_aroma ;
+        :sensoryValue          "20.0"^^xsd:double .
+
 :005754-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Hamburger with Sweet Cherry pairing" ;
         :hasKeyIngredient      :005754 ;
@@ -6342,6 +6334,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001448 ;
         :matchScore            "0.00377358496189117"^^xsd:double .
 
+:cf55bf8f-87c3-4b9e-bc47-aa5cad225d81
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pineapple_aroma ;
+        :sensoryValue          "2.25"^^xsd:double .
+
 :005760-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Armagnac pairing" ;
         :hasKeyIngredient      :005760 ;
@@ -6359,6 +6356,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000090 ;
         :hasRelatedIngredient  :000072 ;
         :matchScore            "0.0681198909878731"^^xsd:double .
+
+:6456654b-dcad-4281-8b60-78e1fee4a6f9
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :apple_aroma ;
+        :sensoryValue          "3.25"^^xsd:double .
 
 :000876-000123  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Rosemary pairing" ;
@@ -6412,11 +6414,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000520 ;
         :hasRelatedIngredient  :006471 ;
         :matchScore            "0.307692319154739"^^xsd:double .
-
-:a540e182-ac6c-41b7-abc1-e241907960d4
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "4.5"^^xsd:double .
 
 :000021-000475  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Pecan Nut pairing" ;
@@ -6484,11 +6481,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000159 ;
         :matchScore            "0.27008929848671"^^xsd:double .
 
-:db2baa60-8bd2-4f88-bca2-1fc584742b43
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
-
 :000475-000082  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pecan Nut with Belgian Endive pairing" ;
         :hasKeyIngredient      :000475 ;
@@ -6507,9 +6499,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000993 ;
         :matchScore            "0.011428571306169"^^xsd:double .
 
-:b6ee7575-8b96-45b3-81ea-f442d755c63a
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :crunchy_texture ;
+:a1c15074-bb35-4bd6-b31e-2797aff66679
+        rdf:type               :Trigeminal ;
+        :hasSensoryDescriptor  :cooling_trigeminal_taste ;
         :sensoryValue          true .
 
 :000040-000090  rdf:type       :IngredientPairing ;
@@ -6534,7 +6526,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q92581152"^^xsd:anyURI ;
         skos:definition         "Oregano is a fragrant herb with a robust, slightly peppery flavor, often used to season Mediterranean and Italian dishes."@en ;
         skos:prefLabel          "Oregano"@en ;
-        :hasAroma               :c6793d4f-139e-4c69-9981-1d13a09d680a , :7728ddb4-947f-4475-a2f3-6ad636a36350 ;
+        :hasAroma               :7793d215-6349-4513-9fb6-73bd36897abc , :8e1d68ce-aab8-4436-95f2-92af91090e3c ;
         :hasFunctionalBenefit   :Stress , :Bone , :Minerals , :Energy , :Diabetic , :Antioxidant , :Digestion , :Probiotic , :Brain , :Immunity , :Weight-gain ;
         :hasIngredientCategory  :icat:000094 .
 
@@ -6567,6 +6559,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000801 ;
         :hasRelatedIngredient  :000163 ;
         :matchScore            "0.000847457617055625"^^xsd:double .
+
+:0064a81d-3d3b-425e-930b-8d36213b7dee
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "5.0"^^xsd:double .
 
 :000013-000149  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Full-fat Yogurt with Banana pairing" ;
@@ -6687,10 +6684,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.476190477609634"^^xsd:double .
 
-:98e85c53-d95a-4961-bd90-1df60af91f47
+:4c97b760-418a-4b64-a303-d40734fab361
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :vanilla_aroma ;
-        :sensoryValue          "0.0075"^^xsd:double .
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "1.7999999999999998"^^xsd:double .
 
 :001448-001755  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with Cava pairing" ;
@@ -6775,6 +6772,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000072 ;
         :matchScore            "0.0889679715037346"^^xsd:double .
 
+:152d5814-22d6-42e9-b241-0b82efb13e88
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :coffee_aroma ;
+        :sensoryValue          "4.0"^^xsd:double .
+
 :001755-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Tequila Silver pairing" ;
         :hasKeyIngredient      :001755 ;
@@ -6824,9 +6826,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.294871807098389"^^xsd:double .
 
 :bell_pepper_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "bell_pepper_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "bell_pepper_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000920-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Pumpkin pairing" ;
@@ -6842,6 +6843,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
 
 :sour_taste  rdf:type   :SensoryDescriptor ;
         skos:prefLabel  "sour_taste"@en .
+
+:9649d7de-a8b7-45b7-a39b-c39cc32ebf91
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :maple_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000013-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Full-fat Yogurt with Plum pairing" ;
@@ -6902,11 +6908,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005930 ;
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.146198824048042"^^xsd:double .
-
-:81376944-99a4-4056-8e38-e76e4928e27b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cocoa_aroma ;
-        :sensoryValue          "1.5"^^xsd:double .
 
 :006821-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Armagnac pairing" ;
@@ -7215,6 +7216,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.0996677726507187"^^xsd:double .
 
+:c636a3df-0e66-4d20-abee-d179cc8c7132
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :coconut_aroma ;
+        :sensoryValue          "5.0"^^xsd:double .
+
 :000252-000182  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Potato with Celery pairing" ;
         :hasKeyIngredient      :000252 ;
@@ -7347,6 +7353,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000072 ;
         :matchScore            "0.0158730167895555"^^xsd:double .
 
+:e3e722ab-94da-4f67-96ec-00c45fc96176
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :hazelnut_aroma ;
+        :sensoryValue          "2.4000000000000004"^^xsd:double .
+
 :000787-000017  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vanilla 'Bourbon' with Tomato pairing" ;
         :hasKeyIngredient      :000787 ;
@@ -7447,11 +7458,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.100000001490116"^^xsd:double .
 
-:7463a914-26ea-478a-b686-a5be63bf5ef1
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "3.2"^^xsd:double .
-
 :000920-005569  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Pear pairing" ;
         :hasKeyIngredient      :000920 ;
@@ -7494,11 +7500,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000104 ;
         :matchScore            "0.03125"^^xsd:double .
 
-:2ac6f933-440f-4c9a-860a-14176dd796f9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :apple_aroma ;
-        :sensoryValue          "3.25"^^xsd:double .
-
 :000182-005569  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Celery with Pear pairing" ;
         :hasKeyIngredient      :000182 ;
@@ -7540,6 +7541,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000030 ;
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.0643086805939674"^^xsd:double .
+
+:df37c31d-90ed-41dc-8ef1-6b6c511d2d22
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pineapple_aroma ;
+        :sensoryValue          "2.25"^^xsd:double .
 
 :000787-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vanilla 'Bourbon' with Dark Chocolate pairing" ;
@@ -7606,6 +7612,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000355 ;
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.344827592372894"^^xsd:double .
+
+:91dc6c02-436c-4d26-829e-55283498c3ef
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "5.0"^^xsd:double .
 
 :000090-000920  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Cucumber pairing" ;
@@ -7685,11 +7696,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007105 ;
         :hasRelatedIngredient  :000017 ;
         :matchScore            "0.244518265128136"^^xsd:double .
-
-:3d568837-f4a7-4d84-bc31-031b1eb66733
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.25"^^xsd:double .
 
 :000083-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Dark Chocolate pairing" ;
@@ -7886,11 +7892,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.0472972989082336"^^xsd:double .
 
-:50af1626-c68d-4ff2-afcb-cd58b2253024
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "0.625"^^xsd:double .
-
 :000151-005545  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pineapple with Mussel pairing" ;
         :hasKeyIngredient      :000151 ;
@@ -7914,6 +7915,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001394 ;
         :hasRelatedIngredient  :005545 ;
         :matchScore            "0.00738007389008999"^^xsd:double .
+
+:26566b26-d659-41f4-a781-319c98ce801a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :berry_aroma ;
+        :sensoryValue          "9.5"^^xsd:double .
 
 :000040-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Basil Leaf pairing" ;
@@ -8053,11 +8059,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.00784313771873713"^^xsd:double .
 
-:76ec1b18-490d-4031-a039-19fec398197e
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000110-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Leek with Lime pairing" ;
         :hasKeyIngredient      :000110 ;
@@ -8106,6 +8107,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.0533333346247673"^^xsd:double .
 
+:18430806-48a3-4c03-99a5-2998d2bd8b0b
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "0.4"^^xsd:double .
+
 :000355-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Green Bean pairing" ;
         :hasKeyIngredient      :000355 ;
@@ -8129,6 +8135,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000887 ;
         :hasRelatedIngredient  :000306 ;
         :matchScore            "0.0799999982118607"^^xsd:double .
+
+:1a0ac4c2-d4dc-41b5-8c60-134ca1954a39
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
 
 :005760-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Cow Mozzarella pairing" ;
@@ -8202,11 +8213,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000163 ;
         :matchScore            "0.034042552113533"^^xsd:double .
 
-:141e8465-5e9d-469b-b59b-0fa7614658fe
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :fatty_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :icat:000144  rdf:type   skos:Concept , :IngredientCategory ;
         skos:definition  "A dish refers to a prepared and cooked food item that is intended to be consumed as a single serving. It can consist of one or more ingredients that have been combined and cooked together to create a specific flavor, texture, and presentation."@en ;
         skos:prefLabel   "Dish Category"@en .
@@ -8228,11 +8234,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000306 ;
         :hasRelatedIngredient  :005675 ;
         :matchScore            "0.0105527639389038"^^xsd:double .
-
-:e49aec28-5583-4fc5-9af5-e277b7b5b6ec
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "7.5"^^xsd:double .
 
 :000163-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Hamburger pairing" ;
@@ -8276,6 +8277,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000030 ;
         :matchScore            "0.0588235296308994"^^xsd:double .
 
+:1e965169-cb02-466a-a188-0347ebe510ed
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.07500000000000001"^^xsd:double .
+
 :000072-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemon with Turkey pairing" ;
         :hasKeyIngredient      :000072 ;
@@ -8306,10 +8312,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000182 ;
         :matchScore            "0.0500000007450581"^^xsd:double .
 
-:milk_aroma  rdf:type    :SensoryDescriptor ;
-        skos:prefLabel   "milk_aroma"@en ;
-        :aromaIntensity  "2.0"^^xsd:double ;
-        :hasAromaType    :cheesy .
+:milk_aroma  rdf:type   :SensoryDescriptor ;
+        skos:prefLabel  "milk_aroma"@en ;
+        :hasAromaType   :cheesy .
 
 :000136-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Tequila Silver pairing" ;
@@ -8394,10 +8399,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.0769230797886848"^^xsd:double .
 
-:6ed8ef42-a2ae-4f13-84d3-11cc17a9c31d
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
+:56d297e8-ff18-4486-8d0a-5d5a3dfc0025
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "2.6999999999999997"^^xsd:double .
 
 :000520-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brussels Sprouts with Jasmine Tea pairing" ;
@@ -8446,6 +8451,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :008970 ;
         :hasRelatedIngredient  :000865 ;
         :matchScore            "0.0551601424813271"^^xsd:double .
+
+:7d2072fd-0803-42b2-9ea2-fb52e8a9cf8b
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :fatty_taste ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :000876-000151  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Pineapple pairing" ;
@@ -8499,7 +8509,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q263203"^^xsd:anyURI ;
         skos:definition         "Crunchy and colorful vegetable used in salads and coleslaws for its vibrant hue and mild flavor."@en ;
         skos:prefLabel          "Red Cabbage"@en ;
-        :hasAroma               :16059bc8-704f-4d31-ba02-377f8dbc5f98 , :a3829290-4c9d-4289-94ae-2d01ce8b173a , :cb90fdcd-4f92-42ca-ae21-f10dab8a737d , :675218f9-23dd-4ec6-9d1b-a62d56565359 ;
+        :hasAroma               :c253018f-7609-441c-9452-2fab68e6fec2 , :299c82ae-856f-4a7e-b5ef-b11d4638a8da , :c27498ed-2038-4ab9-a0b3-4a9dd75c8d72 , :46ab4dad-a191-4215-9b04-d4f56c4b4584 ;
         :hasFunctionalBenefit   :Stress , :Antioxidant , :Energy , :Diabetic , :Digestion ;
         :hasIngredientCategory  :icat:000130 .
 
@@ -8545,10 +8555,15 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000047 ;
         :matchScore            "0.0327868834137917"^^xsd:double .
 
-:2b0874fe-04d1-4c4f-bd48-c6a8da384b52
+:31ec9fe8-f439-4316-b83b-e4d8d7113d7d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pungent_aroma ;
+        :sensoryValue          "21.0"^^xsd:double .
+
+:f7656fb3-7ed5-40a6-8c4b-dd4e63e8dd6c
         rdf:type               :Taste ;
         :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
+        :sensoryValue          "1.0"^^xsd:double .
 
 :icat:000089  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000014 ;
@@ -8560,6 +8575,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000078 ;
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.0441176481544971"^^xsd:double .
+
+:887ef3a2-8a43-44c2-b5f5-7eba3805b193
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "8.5"^^xsd:double .
 
 :001394-000104  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Goat Cheese pairing" ;
@@ -8821,16 +8841,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.384415596723557"^^xsd:double .
 
+:977ef3cd-d455-4223-b274-ef9438db85e9
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pineapple_aroma ;
+        :sensoryValue          "2.25"^^xsd:double .
+
 :005930-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Basil Leaf pairing" ;
         :hasKeyIngredient      :005930 ;
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.116959065198898"^^xsd:double .
-
-:bc0d89ef-8ac6-474f-9829-76589588deed
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :anise_aroma ;
-        :sensoryValue          "2.75"^^xsd:double .
 
 :007105-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Yellow Nectarine pairing" ;
@@ -8843,11 +8863,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000017 ;
         :hasRelatedIngredient  :000014 ;
         :matchScore            "0.0628535524010658"^^xsd:double .
-
-:f77f2884-3836-49cd-a5a3-da7dc2c33827
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :meaty_aroma ;
-        :sensoryValue          "4.2"^^xsd:double .
 
 :000101-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Emmentaler with Cow Mozzarella pairing" ;
@@ -8944,16 +8959,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000920 ;
         :matchScore            "0.0882352963089943"^^xsd:double .
 
+:c97ce39a-dff9-42f9-a4ad-d52d940fb04f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :spicy_aroma ;
+        :sensoryValue          "1.5"^^xsd:double .
+
 :006473-000281  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster with Coriander Seed pairing" ;
         :hasKeyIngredient      :006473 ;
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.181818187236786"^^xsd:double .
 
-:67443454-38e0-443b-9573-54bfb2a4d3d2
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.8"^^xsd:double .
+:c9420e93-54fc-423e-adce-d887a773a09c
+        rdf:type               :Trigeminal ;
+        :hasSensoryDescriptor  :cooling_trigeminal_taste ;
+        :sensoryValue          true .
 
 :000472-000104  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Goat Cheese pairing" ;
@@ -8989,10 +9009,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.0222222227603197"^^xsd:double .
 
-:5334e44e-ac9a-4fe9-b9fd-d2a8cd1a1bd3
+:cf2e4cb9-293a-4394-8773-6bdd2fb22b59
         rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
 
 :000059-000355  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Sweet Corn pairing" ;
@@ -9023,6 +9043,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000163 ;
         :hasRelatedIngredient  :001959 ;
         :matchScore            "0.0634920671582222"^^xsd:double .
+
+:6c9bf865-eae7-4fc2-a9e5-70a97c6dfbec
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :ethanol_aroma ;
+        :sensoryValue          "18.0"^^xsd:double .
 
 :000136-000993  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Tabasco pairing" ;
@@ -9061,9 +9086,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.15748031437397"^^xsd:double .
 
 :jasmin_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "jasmin_aroma"@en ;
-        :aromaIntensity  "3.25"^^xsd:double ;
-        :hasAromaType    :floral .
+        skos:prefLabel  "jasmin_aroma"@en ;
+        :hasAromaType   :floral .
 
 :000886-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Whisky with Jasmine Tea pairing" ;
@@ -9201,6 +9225,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:broader     :icat:000007 ;
         skos:definition  "Refers to a dairy product made by churning cream or milk, commonly used as a cooking fat or spread."@en ;
         skos:prefLabel   "Butter"@en .
+
+:9aba9679-2a7c-47db-ab34-35b65e462972
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :vanilla_aroma ;
+        :sensoryValue          "0.0075"^^xsd:double .
 
 :000452-000306  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Atlantic Salmon pairing" ;
@@ -9352,6 +9381,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000030 ;
         :matchScore            "0.114285714924335"^^xsd:double .
 
+:578fc772-7b79-4355-a290-b00977714956
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :woody_aroma ;
+        :sensoryValue          "0.15"^^xsd:double .
+
 :000055-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Grape pairing" ;
         :hasKeyIngredient      :000055 ;
@@ -9436,6 +9470,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000865 ;
         :matchScore            "0.205882355570793"^^xsd:double .
 
+:222456c5-743d-4b20-bcba-ad19005f591f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :tea_aroma ;
+        :sensoryValue          "0.55"^^xsd:double .
+
 :000159-003290  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Grapefruit with Brie pairing" ;
         :hasKeyIngredient      :000159 ;
@@ -9448,6 +9487,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003143 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
 
+:fc77f3bd-49e0-4273-9111-95c5d3e6da5e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pineapple_aroma ;
+        :sensoryValue          "0.45"^^xsd:double .
+
 :006821-000252  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Sweet Potato pairing" ;
         :hasKeyIngredient      :006821 ;
@@ -9459,11 +9503,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.100000001490116"^^xsd:double .
-
-:1e27501c-f2f6-427d-a98e-4a608201b4e8
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :creamy_texture ;
-        :sensoryValue          true .
 
 :000144-001959  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Grappa pairing" ;
@@ -9519,6 +9558,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.0769230797886848"^^xsd:double .
 
+:48d86a51-d0af-482f-bd6a-15d1d329ed5d
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "3.0"^^xsd:double .
+
 :000181-000082  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Belgian Endive pairing" ;
         :hasKeyIngredient      :000181 ;
@@ -9573,11 +9617,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.204089224338531"^^xsd:double .
 
-:d992fc4f-5844-4e90-8b89-855a459868cc
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "3.0"^^xsd:double .
-
 :Probiotic  rdf:type     :FunctionalBenefit ;
         skos:definition  "Probiotics are live microorganisms that provide health benefits when consumed, particularly in aiding digestion and supporting a healthy gut microbiome." ;
         skos:prefLabel   "Probiotic"@en .
@@ -9588,10 +9627,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000840 ;
         :matchScore            "0.680000007152557"^^xsd:double .
 
-:clove_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "clove_aroma"@en ;
-        :aromaIntensity  "1.5"^^xsd:double ;
-        :hasAromaType    :spicy .
+:clove_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "clove_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :000142-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Pea pairing" ;
@@ -9603,7 +9641,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q188879"^^xsd:anyURI ;
         skos:definition         "Popular fish known for its tender, pink flesh and mild, slightly sweet flavor, making it a versatile choice for various culinary preparations."@en ;
         skos:prefLabel          "Atlantic Salmon"@en ;
-        :hasAroma               :d4343bad-0996-4590-8651-b1ff0caf0931 , :52457140-48db-4eaf-bc2b-96cbb299b574 , :36864fb2-3cd3-45ef-83ae-02806bd43920 ;
+        :hasAroma               :ae833eb6-f0c4-4535-96a7-4e754f514105 , :4c97b760-418a-4b64-a303-d40734fab361 , :da5ded1a-417b-4537-bef2-7a9fa488eff0 ;
         :hasFunctionalBenefit   :Antioxidant , :Weight-gain , :Minerals , :Bone , :Immunity , :Cardiovascular , :Vitamins , :Digestion , :Energy , :Brain ;
         :hasIngredientCategory  :icat:000105 .
 
@@ -9727,6 +9765,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005760 ;
         :matchScore            "0.146179407835007"^^xsd:double .
 
+:4632a11e-5819-4cb3-bca4-1617b351c94d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :asparagus_aroma ;
+        :sensoryValue          "14.0"^^xsd:double .
+
 :000163-005842  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Garlic Puree pairing" ;
         :hasKeyIngredient      :000163 ;
@@ -9793,6 +9836,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.142857149243355"^^xsd:double .
 
+:f7aa77fd-7595-40cf-9283-278e77cced8f
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.8"^^xsd:double .
+
 :001448-000141  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with Yellow Peach pairing" ;
         :hasKeyIngredient      :001448 ;
@@ -9840,6 +9888,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007170 ;
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.415841579437256"^^xsd:double .
+
+:bf5b2dc7-10c4-416a-a41e-82f713762ce7
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "4.5"^^xsd:double .
 
 :007088-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Armagnac with Oyster Mushroom pairing" ;
@@ -9970,6 +10023,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000887 ;
         :hasRelatedIngredient  :000149 ;
         :matchScore            "0.184615388512611"^^xsd:double .
+
+:d64c03af-ce32-4755-b738-1a5a8c22f9a0
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "2.55"^^xsd:double .
 
 :000105-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Green Bean with Oyster Mushroom pairing" ;
@@ -10364,9 +10422,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.107692308723927"^^xsd:double .
 
 :floral_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "floral_aroma"@en ;
-        :aromaIntensity  "3.5"^^xsd:double ;
-        :hasAromaType    :floral .
+        skos:prefLabel  "floral_aroma"@en ;
+        :hasAromaType   :floral .
 
 :005509-003143  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Long-Grain Rice with Fourme D'Ambert pairing" ;
@@ -10476,10 +10533,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000215 ;
         :matchScore            "0.316455692052841"^^xsd:double .
 
-:berry_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "berry_aroma"@en ;
-        :aromaIntensity  "9.5"^^xsd:double ;
-        :hasAromaType    :fruity .
+:berry_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "berry_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000148-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mango with Lemon pairing" ;
@@ -10560,9 +10616,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.00666666682809591"^^xsd:double .
 
 :herbal_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "herbal_aroma"@en ;
-        :aromaIntensity  "7.0"^^xsd:double ;
-        :hasAromaType    :herbal .
+        skos:prefLabel  "herbal_aroma"@en ;
+        :hasAromaType   :herbal .
 
 :000031-000141  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemongrass with Yellow Peach pairing" ;
@@ -10701,10 +10756,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.126559719443321"^^xsd:double .
 
-:anise_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "anise_aroma"@en ;
-        :aromaIntensity  "5.5"^^xsd:double ;
-        :hasAromaType    :spicy .
+:anise_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "anise_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :000096-007109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chives with Fig pairing" ;
@@ -10748,10 +10802,15 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000059 ;
         :matchScore            "0.0544959120452404"^^xsd:double .
 
-:7f46ac2c-3356-423e-ac87-11edf7e66b83
+:e5660f44-eb86-4470-be26-93a86c23318c
         rdf:type               :Aroma ;
         :hasSensoryDescriptor  :honey_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
+        :sensoryValue          "15.0"^^xsd:double .
+
+:92be6278-d122-413c-bb3d-11b6957730f3
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :spicy_aroma ;
+        :sensoryValue          "0.44999999999999996"^^xsd:double .
 
 :000082-000182  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Belgian Endive with Celery pairing" ;
@@ -10770,11 +10829,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005754 ;
         :hasRelatedIngredient  :001624 ;
         :matchScore            "0.132835820317268"^^xsd:double .
-
-:80d7c7f3-a8d9-491d-a0e5-bc738c4dd1d0
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "3.0"^^xsd:double .
 
 :005509-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Long-Grain Rice with Pea pairing" ;
@@ -10878,11 +10932,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.326975464820862"^^xsd:double .
 
+:87d473fd-4479-4664-9bd5-7306809b7d34
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
 :006473-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster with Green Bean pairing" ;
         :hasKeyIngredient      :006473 ;
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.0199999995529652"^^xsd:double .
+
+:1026b9e4-3204-4488-bc1d-37963d197946
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :acidic_aroma ;
+        :sensoryValue          "3.5"^^xsd:double .
 
 :001959-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grappa with Mustard pairing" ;
@@ -10968,6 +11032,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.535114526748657"^^xsd:double .
 
+:1a4e48bb-6019-4cde-9393-7e45234db584
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :001008-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk Chocolate with Acacia Honey pairing" ;
         :hasKeyIngredient      :001008 ;
@@ -10978,8 +11047,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q1062531"^^xsd:anyURI ;
         skos:definition         "An egg that has been cooked in boiling water, resulting in a firm white and a partially solid yolk."@en ;
         skos:prefLabel          "Boiled Egg"@en ;
-        :hasAroma               :502ea1f9-88d5-4d31-8a5b-fbdf6fa7e8bb ;
-        :hasFunctionalBenefit   :Brain , :Vitamins , :Skin-health , :Prebiotic , :Muscle-gain , :Calcium-source , :Stress , :Energy , :Minerals , :Antioxidant , :Probiotic , :Immunity , :Bone , :Diabetic , :Weight-loss , :Digestion , :Weight-gain , :Nervous-system , :Sleep , :Cardiovascular , :Ageing ;
+        :hasAroma               :adfe6de9-5747-4689-8566-639e3d7a8a6b ;
+        :hasFunctionalBenefit   :Brain , :Vitamins , :Skin-health , :Prebiotic , :Muscle-gain , :Calcium-source , :Stress , :Energy , :Minerals , :Antioxidant , :Probiotic , :Bone , :Immunity , :Diabetic , :Weight-loss , :Digestion , :Weight-gain , :Nervous-system , :Sleep , :Cardiovascular , :Ageing ;
         :hasIngredientCategory  :icat:000007 .
 
 :000014-000110  rdf:type       :IngredientPairing ;
@@ -11054,9 +11123,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.121951222419739"^^xsd:double .
 
 :buttery_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "buttery_aroma"@en ;
-        :aromaIntensity  "2.25"^^xsd:double ;
-        :hasAromaType    :cheesy .
+        skos:prefLabel  "buttery_aroma"@en ;
+        :hasAromaType   :cheesy .
 
 :000791-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Cow Mozzarella pairing" ;
@@ -11069,6 +11137,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000252 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.800000011920929"^^xsd:double .
+
+:f896f07c-e6a3-4a4d-8d5e-6be6b80d991c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "0.25"^^xsd:double .
 
 :000163-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Milk pairing" ;
@@ -11167,10 +11240,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000182 ;
         :matchScore            "0.015338983386755"^^xsd:double .
 
-:fishy_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "fishy_aroma"@en ;
-        :aromaIntensity  "1.25"^^xsd:double ;
-        :hasAromaType    :animal .
+:fishy_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "fishy_aroma"@en ;
+        :hasAromaType   :animal .
 
 :000110-001008  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Leek with Milk Chocolate pairing" ;
@@ -11209,9 +11281,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.320952385663986"^^xsd:double .
 
 :pungent_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "pungent_aroma"@en ;
-        :aromaIntensity  "10.5"^^xsd:double ;
-        :hasAromaType    :spicy .
+        skos:prefLabel  "pungent_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :000840-000357  rdf:type       :IngredientPairing ;
         skos:prefLabel         "London Dry Gin with Oregano pairing" ;
@@ -11393,6 +11464,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.0295081958174706"^^xsd:double .
 
+:7de14d63-f922-4e30-842a-eca97b2f98c6
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "0.5"^^xsd:double .
+
 :000040-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Lemon pairing" ;
         :hasKeyIngredient      :000040 ;
@@ -11410,16 +11486,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :006471 ;
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.0320000015199184"^^xsd:double .
-
-:081ad76b-a30c-4772-8c39-9ee0e20abb84
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "2.8000000000000003"^^xsd:double .
-
-:7bfab38f-985a-4154-ac08-57211e1c271b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :ethanol_aroma ;
-        :sensoryValue          "18.0"^^xsd:double .
 
 :005675-005509  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Long-Grain Rice pairing" ;
@@ -11449,16 +11515,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q503"^^xsd:anyURI ;
         skos:definition         "Yellow, curved fruits with a creamy texture and a sweet, mild flavor."@en ;
         skos:prefLabel          "Banana"@en ;
-        :hasAroma               :056189cf-a030-4a62-b2d5-20a648de1c64 , :377a5920-acd9-4319-bfd2-5050d108a6ca , :714eb6cf-e59e-4fef-b755-21817f754187 ;
+        :hasAroma               :f795b808-30e9-4d89-96ac-a35fcc095907 , :a480df64-f7cd-498c-91b7-fbf019c51046 , :f9a950ce-f802-43fb-8d8d-e7e12392867e ;
         :hasFunctionalBenefit   :Minerals , :Stress , :Cardiovascular , :Digestion , :Energy , :Prebiotic , :Bone , :Nervous-system , :Weight-gain , :Satiety , :Immunity , :Weight-loss , :Antioxidant , :Probiotic , :Diabetic , :Vitamins , :Brain ;
         :hasIngredientCategory  :icat:000093 ;
-        :hasTaste               :aaa4cbec-5980-402b-8325-9a53fb5affb8 .
+        :hasTaste               :bd4d7060-07ca-4d18-9437-6ea69f75c530 .
 
 :000133-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Yellow Grapefruit pairing" ;
         :hasKeyIngredient      :000133 ;
         :hasRelatedIngredient  :000159 ;
         :matchScore            "0.157024532556534"^^xsd:double .
+
+:1fa6a5d3-4eb3-4623-8ee1-60c4041185c3
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :vanilla_aroma ;
+        :sensoryValue          "0.375"^^xsd:double .
 
 :000072-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemon with Blueberry pairing" ;
@@ -11622,16 +11693,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q36814998"^^xsd:anyURI ;
         skos:definition         "Dark leafy green vegetable known for its tender leaves and mild, slightly earthy taste, commonly used in salads, sautés, and as a versatile ingredient."@en ;
         skos:prefLabel          "Spinach"@en ;
-        :hasAroma               :31fb6623-8255-47fb-bd5a-81817504ec35 , :b56fc844-a110-4fdb-92d7-ce2e9aff5bf3 , :03478de7-b62c-4bfa-921c-48c93a693df7 , :41b2828a-8c27-435a-8cba-cb9f4505216c ;
+        :hasAroma               :bd68b55d-1042-43f3-afe9-2acc2a765d8c , :ef496209-9e5c-4783-97f6-ddf7f7db3ba6 , :2d85c44b-8afa-465d-a555-8aa9039b4012 , :189f2af8-410b-4c03-b87d-843457a910cc ;
         :hasFunctionalBenefit   :Energy , :Bone , :Diabetic , :Probiotic , :Antioxidant , :Weight-loss , :Digestion , :Satiety , :Vitamins , :Minerals , :Calcium-source , :Brain ;
         :hasIngredientCategory  :icat:000139 ;
-        :hasTaste               :3770d841-d340-4dc5-bd51-9a11a35067e4 .
+        :hasTaste               :a3d0456c-97c3-4e27-aed0-3906545d4ca3 .
 
 :005942-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Chorizo pairing" ;
         :hasKeyIngredient      :005942 ;
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.200204983353615"^^xsd:double .
+
+:3bd06ef6-e2dd-488a-a971-73cb9313d22e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "7.5"^^xsd:double .
 
 :000013-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Full-fat Yogurt with Cantaloupe Melon pairing" ;
@@ -11651,6 +11727,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000151 ;
         :matchScore            "0.188543692231178"^^xsd:double .
 
+:45e02b7a-c4b1-4b53-b003-551a3e4b06be
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :creamy_aroma ;
+        :sensoryValue          "0.4"^^xsd:double .
+
 :007170-000801  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Cocoa Powder pairing" ;
         :hasKeyIngredient      :007170 ;
@@ -11669,6 +11750,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003143 ;
         :matchScore            "0.0615782514214516"^^xsd:double .
 
+:f39f0f84-2eb9-480f-88ad-2109da4b9ce5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cabbage_aroma ;
+        :sensoryValue          "4.75"^^xsd:double .
+
 :000104-000141  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Yellow Peach pairing" ;
         :hasKeyIngredient      :000104 ;
@@ -11681,11 +11767,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.130267173051834"^^xsd:double .
 
-:944ae229-5c90-4e57-8804-573c25a1fad9
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :melting_texture ;
-        :sensoryValue          true .
-
 :000083-000357  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Oregano pairing" ;
         :hasKeyIngredient      :000083 ;
@@ -11697,11 +11778,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003290 ;
         :hasRelatedIngredient  :000101 ;
         :matchScore            "-7.66666650772095"^^xsd:double .
-
-:53c47c69-c7c1-46f8-b1f4-83e67afe6987
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "1.8"^^xsd:double .
 
 :000306-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Brewed Coffee pairing" ;
@@ -11716,9 +11792,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.355263143777847"^^xsd:double .
 
 :cheesy_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "cheesy_aroma"@en ;
-        :aromaIntensity  "1.25"^^xsd:double ;
-        :hasAromaType    :cheesy .
+        skos:prefLabel  "cheesy_aroma"@en ;
+        :hasAromaType   :cheesy .
 
 :006821-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Cheddar pairing" ;
@@ -11742,11 +11817,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000181 ;
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.444444447755814"^^xsd:double .
-
-:8361d91b-e32f-44c6-a8b9-0680bb03895e
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :camphor_aroma ;
-        :sensoryValue          "7.0"^^xsd:double .
 
 :000090-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Calvados pairing" ;
@@ -11830,11 +11900,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q12372598"^^xsd:anyURI ;
         skos:definition         "Juicy stone fruits with a sweet and tart flavor, commonly eaten fresh or used in jams and desserts."@en ;
         skos:prefLabel          "Plum"@en ;
-        :hasAroma               :fa27db00-9047-473c-b323-c3bae92cffc6 , :b2684c46-7baa-4cc4-9585-f24a773fdbd9 , :20aa6bf6-c6a6-42f5-bbe5-4a830d5d107f ;
+        :hasAroma               :977ef3cd-d455-4223-b274-ef9438db85e9 , :357b5f08-b837-4de6-bbbd-53e8ab2a99d1 , :15e08909-49a6-4337-9c57-4e9a6a9b176c ;
         :hasFunctionalBenefit   :Stress , :Brain , :Antibacterial , :Immunity , :Digestion , :Antioxidant , :Energy , :Cardiovascular , :Bone , :Prebiotic , :Diabetic ;
         :hasIngredientCategory  :icat:000092 ;
-        :hasTaste               :3dc7f22c-9cf0-4c62-97fe-abae7ea12bb6 , :d74e472f-ba2d-41ad-9fad-88a8f7f96793 ;
-        :hasTrigeminal          :f7af39d9-9c9a-4b39-af18-2ccfd6538096 .
+        :hasTaste               :170dd8ff-e7a9-4573-ad20-96a64e7e9ad5 , :c2216f17-02b4-40ad-89e5-b122f77e348d ;
+        :hasTrigeminal          :57492bce-5679-451a-ad74-4d7d51e97574 .
 
 :000306-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Sweet Cherry pairing" ;
@@ -12010,11 +12080,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.0475435815751553"^^xsd:double .
 
-:63a90b3b-1704-492a-af92-2a34e18c4b74
-        rdf:type               :Trigeminal ;
-        :hasSensoryDescriptor  :tingling_trigeminal_taste ;
-        :sensoryValue          true .
-
 :000213-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :000213 ;
@@ -12069,11 +12134,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.0769230797886848"^^xsd:double .
 
-:dc0fb51d-7958-411f-9799-b7032888f06f
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "0.7000000000000001"^^xsd:double .
-
 :003290-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :003290 ;
@@ -12090,10 +12150,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q2376488"^^xsd:anyURI ;
         skos:definition         "Gruyère is a Swiss cheese with a rich, nutty flavor, commonly used in cooking, baking, and as a topping."@en ;
         skos:prefLabel          "Gruyère"@en ;
-        :hasAroma               :2cf87378-f57a-4697-814c-b5ed3e71c776 , :80dd1d53-301f-4b33-ba3a-097286198f2a , :22453277-a8fe-4105-8600-958a609af6b7 , :9e531552-3900-4d7b-959b-4d307316c840 ;
+        :hasAroma               :3fb70f4e-0da3-4f7c-9859-b9e704db8cb7 , :ddf6bb9f-f84a-4858-9b46-bd10c8406f68 , :871902c4-131c-4a4f-967f-3388ab83d3b2 , :60a400b9-649f-4c5b-b501-634bd229156e ;
         :hasIngredientCategory  :icat:000055 ;
-        :hasTaste               :50f14785-acf5-48f2-be53-88838594f1ac , :dd7c706f-f73e-444e-b3b9-6735d64730cb ;
-        :hasTexture             :df949c44-17c5-4902-a648-18cf5dbdee45 , :008f3d33-6bfb-49df-a51a-3f76f5ef04d4 .
+        :hasTaste               :0f8dccd4-2873-4d9a-b084-e3b597522eb8 , :e328bb57-18b8-4ec2-b19b-e0454e4bf65c ;
+        :hasTexture             :e74f673c-f3dc-43bd-9a0e-34afe1330797 , :c05e96c0-0d14-4307-ae64-0a268608f029 .
 
 :000873-000475  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Pecan Nut pairing" ;
@@ -12113,6 +12173,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000017 ;
         :matchScore            "0.0625"^^xsd:double .
 
+:add49d36-b6d6-43c0-9786-c548edcc800b
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "2.55"^^xsd:double .
+
 :005942-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Grape pairing" ;
         :hasKeyIngredient      :005942 ;
@@ -12129,6 +12194,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:broader     :icat:000002 ;
         skos:definition  "Refers to the edible seeds of the rice plant, often consumed as a staple food in many cultures."@en ;
         skos:prefLabel   "Rice"@en .
+
+:7fd4c457-de1a-4ff7-bbe7-d816860b9f5c
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
+:23a4aada-4bd6-4a2f-b86c-c00c64a1a81d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :potato_aroma ;
+        :sensoryValue          "2.0999999999999996"^^xsd:double .
 
 :000252-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Potato with Jasmine Tea pairing" ;
@@ -12344,10 +12419,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.37946429848671"^^xsd:double .
 
-:honey_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "honey_aroma"@en ;
-        :aromaIntensity  "5.0"^^xsd:double ;
-        :hasAromaType    :floral .
+:honey_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "honey_aroma"@en ;
+        :hasAromaType   :floral .
 
 :000311-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Yellow Nectarine pairing" ;
@@ -12367,11 +12441,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000096 ;
         :matchScore            "0.0556483045220375"^^xsd:double .
 
-:2d71ffd4-03a8-4e56-9906-4fe1dafdad50
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "2.6999999999999997"^^xsd:double .
-
 :000040-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Hamburger pairing" ;
         :hasKeyIngredient      :000040 ;
@@ -12383,11 +12452,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005622 ;
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.222857147455215"^^xsd:double .
-
-:14d534cd-a6b7-47af-9eff-ec86daca2b5c
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "1.5"^^xsd:double .
 
 :000213-000801  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Cocoa Powder pairing" ;
@@ -12449,11 +12513,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.0266666673123837"^^xsd:double .
 
+:73c42013-8eab-4e3a-af7a-4849611d09ab
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "4.5"^^xsd:double .
+
 :007170-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Acacia Honey pairing" ;
         :hasKeyIngredient      :007170 ;
         :hasRelatedIngredient  :007105 ;
         :matchScore            "0.0160396043211222"^^xsd:double .
+
+:ae833eb6-f0c4-4535-96a7-4e754f514105
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fishy_aroma ;
+        :sensoryValue          "4.0"^^xsd:double .
 
 :000144-000281  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Coriander Seed pairing" ;
@@ -12504,11 +12578,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000155 ;
         :hasRelatedIngredient  :000520 ;
         :matchScore            "0.266666680574417"^^xsd:double .
-
-:66b4ffac-5284-4701-9a85-5f3a2fa8220b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :acidic_aroma ;
-        :sensoryValue          "1.05"^^xsd:double .
 
 :007109-000082  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fig with Belgian Endive pairing" ;
@@ -12634,11 +12703,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:definition  "Ingredients or products that may assist in increasing body mass and muscle." ;
         skos:prefLabel   "Weight-gain"@en .
 
-:db5fd720-e6d7-4237-bd25-a874265eb264
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :coffee_aroma ;
-        :sensoryValue          "4.0"^^xsd:double .
-
 :005942-000148  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Mango pairing" ;
         :hasKeyIngredient      :005942 ;
@@ -12675,11 +12739,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.0923076942563057"^^xsd:double .
 
-:069726b6-c9fa-40d9-b5fb-de388d60525e
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.22499999999999998"^^xsd:double .
-
 :005569-006471  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pear with Carrot pairing" ;
         :hasKeyIngredient      :005569 ;
@@ -12692,10 +12751,14 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.322760164737701"^^xsd:double .
 
+:dd8e67d6-04c9-4419-aa21-48e6a9e65001
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :anise_aroma ;
+        :sensoryValue          "2.75"^^xsd:double .
+
 :pineapple_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "pineapple_aroma"@en ;
-        :aromaIntensity  "4.5"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "pineapple_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000157-000091  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Chervil pairing" ;
@@ -12725,11 +12788,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000163 ;
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.333333343267441"^^xsd:double .
-
-:219f5c31-3efb-43ef-af52-94bbc9ba87bd
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "0.8999999999999999"^^xsd:double .
 
 :000791-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Lime pairing" ;
@@ -12855,7 +12913,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q21546392"^^xsd:anyURI ;
         skos:definition         "A pungent bulbous plant used for its aromatic and flavor-enhancing properties in various cuisines."@en ;
         skos:prefLabel          "Garlic"@en ;
-        :hasAroma               :7a73dd1a-3117-44c4-9e96-89ec9b11e806 , :7dd4dff5-26b9-4a61-adbe-f3864c953bb8 ;
+        :hasAroma               :089f561d-3a7e-4335-bdeb-3e304186b3bc , :31ec9fe8-f439-4316-b83b-e4d8d7113d7d ;
         :hasFunctionalBenefit   :Ageing , :Energy , :Vitamins , :Weight-loss , :Prebiotic , :Cardiovascular , :Digestion , :Weight-gain , :Brain , :Antioxidant , :Probiotic , :Immunity , :Diabetic , :Minerals , :Antibacterial , :Bone , :Stress ;
         :hasIngredientCategory  :icat:000127 .
 
@@ -12924,11 +12982,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005760 ;
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.0920000001788139"^^xsd:double .
-
-:ddb6e911-03af-419f-a407-6f4e01495b49
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
 
 :000215-000887  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with White Chocolate pairing" ;
@@ -13092,10 +13145,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.147058829665184"^^xsd:double .
 
-:56baa775-cb94-4c53-9e63-d6a6b0115c55
+:0d6bfa3c-bd3b-4921-863c-60847e4a6bb0
         rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "4.0"^^xsd:double .
 
 :000213-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Veal pairing" ;
@@ -13150,17 +13203,17 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.370873779058456"^^xsd:double .
 
-:000149-000520  rdf:type       :IngredientPairing ;
-        skos:prefLabel         "Banana with Brussels Sprouts pairing" ;
-        :hasKeyIngredient      :000149 ;
-        :hasRelatedIngredient  :000520 ;
-        :matchScore            "0.15950919687748"^^xsd:double .
-
 :000161-000938  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with White Asparagus pairing" ;
         :hasKeyIngredient      :000161 ;
         :hasRelatedIngredient  :000938 ;
         :matchScore            "0.0306729655712843"^^xsd:double .
+
+:000149-000520  rdf:type       :IngredientPairing ;
+        skos:prefLabel         "Banana with Brussels Sprouts pairing" ;
+        :hasKeyIngredient      :000149 ;
+        :hasRelatedIngredient  :000520 ;
+        :matchScore            "0.15950919687748"^^xsd:double .
 
 :003290-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Acacia Honey pairing" ;
@@ -13270,22 +13323,27 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.267857134342194"^^xsd:double .
 
+:1f5503f5-571f-43da-ba71-73399bfd10a2
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :woody_aroma ;
+        :sensoryValue          "0.025"^^xsd:double .
+
 :003143-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Oyster pairing" ;
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :006473 ;
         :matchScore            "0.200000002980232"^^xsd:double .
 
-:cb90fdcd-4f92-42ca-ae21-f10dab8a737d
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :mustard_aroma ;
-        :sensoryValue          "5.25"^^xsd:double .
-
 :001394-000313  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Honey pairing" ;
         :hasKeyIngredient      :001394 ;
         :hasRelatedIngredient  :000313 ;
         :matchScore            "0.258302569389343"^^xsd:double .
+
+:358c5467-d4e3-4135-adc1-cd53a82c1791
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pineapple_aroma ;
+        :sensoryValue          "13.5"^^xsd:double .
 
 :000141-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Milk pairing" ;
@@ -13358,11 +13416,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :008970 ;
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.233985766768456"^^xsd:double .
-
-:8087ea38-e506-4cc5-8cdc-140866e5efd6
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :crispy_texture ;
-        :sensoryValue          true .
 
 :001218-000281  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Coriander Seed pairing" ;
@@ -13496,11 +13549,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001959 ;
         :matchScore            "0.176470592617989"^^xsd:double .
 
-:b43995df-bdf8-478a-9127-616b484c1873
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "8.5"^^xsd:double .
-
 :005622-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Scallop Saint Jacques with Armagnac pairing" ;
         :hasKeyIngredient      :005622 ;
@@ -13602,11 +13650,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :008970 ;
         :matchScore            "0.0438919328153133"^^xsd:double .
 
-:3474f094-524b-422c-a4be-cada032d606f
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :hazelnut_aroma ;
-        :sensoryValue          "2.4000000000000004"^^xsd:double .
-
 :006821-000104  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Goat Cheese pairing" ;
         :hasKeyIngredient      :006821 ;
@@ -13691,6 +13734,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005842 ;
         :matchScore            "0.0222222227603197"^^xsd:double .
 
+:15e08909-49a6-4337-9c57-4e9a6a9b176c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :apple_aroma ;
+        :sensoryValue          "1.625"^^xsd:double .
+
 :006821-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Turkey pairing" ;
         :hasKeyIngredient      :006821 ;
@@ -13726,16 +13774,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000163 ;
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.292063504457474"^^xsd:double .
-
-:ea0e9f63-b7cf-49d7-8f3b-2bf110a93ede
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :buttery_aroma ;
-        :sensoryValue          "0.0225"^^xsd:double .
-
-:d98ade27-b6b8-406b-8494-2e64bfbf97d6
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :honey_aroma ;
-        :sensoryValue          "2.0"^^xsd:double .
 
 :000472-000313  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Honey pairing" ;
@@ -13815,11 +13853,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.352941185235977"^^xsd:double .
 
-:9d66b895-5e8a-454f-a7a2-51b1c6cbc834
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :potato_aroma ;
-        :sensoryValue          "2.0999999999999996"^^xsd:double .
-
 :000472-001959  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Grappa pairing" ;
         :hasKeyIngredient      :000472 ;
@@ -13894,11 +13927,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000938 ;
         :hasRelatedIngredient  :000107 ;
         :matchScore            "0.0373333320021629"^^xsd:double .
-
-:68fbe466-fbb3-4626-81cd-9fe8261dd949
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :milk_aroma ;
-        :sensoryValue          "3.0"^^xsd:double .
 
 :007109-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fig with Oyster pairing" ;
@@ -13988,6 +14016,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000452 ;
         :hasRelatedIngredient  :000515 ;
         :matchScore            "0.170731708407402"^^xsd:double .
+
+:1f70ad19-729f-45c7-a611-8b47243c9bfc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "0.625"^^xsd:double .
 
 :005930-000313  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Honey pairing" ;
@@ -14157,11 +14190,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000104 ;
         :matchScore            "0.0307692307978868"^^xsd:double .
 
-:9d4bb628-ae48-4ffd-94a3-aa91f62a3f4b
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :hard_texture ;
-        :sensoryValue          true .
-
 :000144-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Yellow Nectarine pairing" ;
         :hasKeyIngredient      :000144 ;
@@ -14222,6 +14250,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.0399999991059303"^^xsd:double .
 
+:c05e96c0-0d14-4307-ae64-0a268608f029
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
+
 :000046-000801  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Cocoa Powder pairing" ;
         :hasKeyIngredient      :000046 ;
@@ -14281,11 +14314,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.125"^^xsd:double .
 
-:61cd3600-51e6-42a6-9425-b72c3341fcd3
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :chocolate_aroma ;
-        :sensoryValue          "0.30000000000000004"^^xsd:double .
-
 :000887-005622  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Scallop Saint Jacques pairing" ;
         :hasKeyIngredient      :000887 ;
@@ -14297,6 +14325,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000141 ;
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.116550117731094"^^xsd:double .
+
+:6f9542c8-8e99-44bf-a5bf-77f96f1e77b3
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :milk_aroma ;
+        :sensoryValue          "1.6"^^xsd:double .
 
 :000801-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Brewed Coffee pairing" ;
@@ -14399,12 +14432,12 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13179"^^xsd:anyURI ;
         skos:definition         "Raspberries are small, red or black berries with a tart and sweet flavor, used in various culinary applications."@en ;
         skos:prefLabel          "Raspberry"@en ;
-        :hasAroma               :4b364f51-90a9-4b72-9f11-9f2a25edbe07 , :53d9f411-80f3-4cf0-b29b-e1d58f095d84 , :30f571bc-7564-4ccb-a917-53350d041cea , :4f8ff6c9-248c-4940-a1fb-ddce86c258f0 ;
+        :hasAroma               :22448e58-725d-405a-8eb5-5f72ee8c4fa7 , :26566b26-d659-41f4-a781-319c98ce801a , :f7ede252-920e-4bee-9740-436ee60cdf72 , :0824b9a7-82f0-482e-887c-b7fe69c20603 ;
         :hasFunctionalBenefit   :Probiotic , :Energy , :Sleep , :Brain , :Antibacterial , :Antioxidant , :Stress , :Digestion , :Minerals , :Cardiovascular , :Prebiotic , :Weight-loss , :Diabetic ;
         :hasIngredientCategory  :icat:000088 ;
-        :hasTaste               :f20502d9-15b0-45f5-bc4c-d6e41c1f094b , :8a19792b-3494-4c57-9132-fed908758c59 ;
-        :hasTexture             :c5ca6f27-d54a-44d4-b8a5-49838db2124a ;
-        :hasTrigeminal          :aa6b9a4b-7e0d-465c-aee9-444f7cb316d0 .
+        :hasTaste               :1396a469-bc10-4b80-a82a-54000632d68e , :683c17a3-95c6-4df9-9a0d-003cf03ebfb0 ;
+        :hasTexture             :4925b116-96b0-4d03-96d4-522144a97d1d ;
+        :hasTrigeminal          :62e7b414-0d4b-4ecc-b7d7-38d0dc386f63 .
 
 :000017-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tomato with Baguette pairing" ;
@@ -14468,6 +14501,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000157 ;
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.27601557970047"^^xsd:double .
+
+:a3387a5e-228e-4462-a21e-750ec59d69d9
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :roasted_aroma ;
+        :sensoryValue          "0.17500000000000002"^^xsd:double .
 
 :000313-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Gruyère pairing" ;
@@ -14541,11 +14579,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.133333340287209"^^xsd:double .
 
-:cc1d2af2-0127-44f3-874d-7052e708f941
-        rdf:type               :Trigeminal ;
-        :hasSensoryDescriptor  :cooling_trigeminal_taste ;
-        :sensoryValue          true .
-
 :005842-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Pumpkin pairing" ;
         :hasKeyIngredient      :005842 ;
@@ -14587,11 +14620,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000101 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.300000011920929"^^xsd:double .
-
-:f873e085-3a69-4ff5-9f9d-4cdce14ded84
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :thyme_aroma ;
-        :sensoryValue          "12.0"^^xsd:double .
 
 :000040-000021  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Fish Sauce pairing" ;
@@ -14687,6 +14715,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006821 ;
         :matchScore            "0.154340833425522"^^xsd:double .
 
+:cc3ce379-5e2d-4fa7-a3d1-af96664a6979
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :vanilla_aroma ;
+        :sensoryValue          "0.5249999999999999"^^xsd:double .
+
 :000157-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Green Bean pairing" ;
         :hasKeyIngredient      :000157 ;
@@ -14722,6 +14755,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000123 ;
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.0352941192686558"^^xsd:double .
+
+:0aec95f0-4799-41e1-a76a-c529b9ef57ae
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :jasmin_aroma ;
+        :sensoryValue          "19.5"^^xsd:double .
 
 :000133-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Brussels Sprouts pairing" ;
@@ -14850,10 +14888,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.00952380988746881"^^xsd:double .
 
-:763edcb4-0367-452f-867f-de90a0b78140
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :mustard_aroma ;
-        :sensoryValue          "31.5"^^xsd:double .
+:bd964f2b-3633-4895-bc09-b4a7532e58af
+        rdf:type               :Trigeminal ;
+        :hasSensoryDescriptor  :tingling_trigeminal_taste ;
+        :sensoryValue          true .
 
 :001218-005509  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Long-Grain Rice pairing" ;
@@ -14997,10 +15035,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000215 ;
         :matchScore            "0.25"^^xsd:double .
 
-:675218f9-23dd-4ec6-9d1b-a62d56565359
+:7e3c3199-1afa-4743-8517-26b9729ac60d
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :onion_aroma ;
-        :sensoryValue          "4.8"^^xsd:double .
+        :hasSensoryDescriptor  :banana_aroma ;
+        :sensoryValue          "1.7999999999999998"^^xsd:double .
 
 :000109-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Baguette pairing" ;
@@ -15122,11 +15160,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.0588235296308994"^^xsd:double .
 
-:cccdb869-9b0e-478f-b15a-c70212b0c67a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :buttery_aroma ;
-        :sensoryValue          "0.45"^^xsd:double .
-
 :000887-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Cantaloupe Melon pairing" ;
         :hasKeyIngredient      :000887 ;
@@ -15138,11 +15171,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000030 ;
         :hasRelatedIngredient  :000083 ;
         :matchScore            "0.00321543402969837"^^xsd:double .
-
-:d972e032-d4b7-481c-8587-df6caf8e28d1
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :creamy_aroma ;
-        :sensoryValue          "2.0"^^xsd:double .
 
 :000281-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Baguette pairing" ;
@@ -15276,6 +15304,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005760 ;
         :matchScore            "0.200000002980232"^^xsd:double .
 
+:85406743-5161-4ff4-94e0-c7a152d4927d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fermented_aroma ;
+        :sensoryValue          "1.1"^^xsd:double .
+
 :000059-000082  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Belgian Endive pairing" ;
         :hasKeyIngredient      :000059 ;
@@ -15288,16 +15321,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000355 ;
         :matchScore            "0.25"^^xsd:double .
 
+:29012ec3-3d06-400a-a695-44806efbfdf7
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :creamy_texture ;
+        :sensoryValue          true .
+
 :000149-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Blueberry pairing" ;
         :hasKeyIngredient      :000149 ;
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.102085888385773"^^xsd:double .
-
-:7dd4dff5-26b9-4a61-adbe-f3864c953bb8
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pungent_aroma ;
-        :sensoryValue          "21.0"^^xsd:double .
 
 :001218-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Green Bean pairing" ;
@@ -15354,16 +15387,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.253658533096313"^^xsd:double .
 
+:6e3ef384-08e0-486b-89f9-3d22b3b11c00
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :oat_flakes_cereal_aroma ;
+        :sensoryValue          "0.005"^^xsd:double .
+
 :000117-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Blueberry pairing" ;
         :hasKeyIngredient      :000117 ;
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.0385964922606945"^^xsd:double .
-
-:4d24de36-6a76-40bd-861b-470c76ee2504
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pine_aroma ;
-        :sensoryValue          "0.9"^^xsd:double .
 
 :005622-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Scallop Saint Jacques with Cow Mozzarella pairing" ;
@@ -15400,11 +15433,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000151 ;
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.0968749970197678"^^xsd:double .
-
-:7e5f8a03-6f4d-436e-a7d0-3c1b234c4118
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.25"^^xsd:double .
 
 :000133-000840  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with London Dry Gin pairing" ;
@@ -15448,11 +15476,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.148148149251938"^^xsd:double .
 
-:34731204-6f1a-4fd8-8b71-a40eb08d5944
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :bitter_taste ;
-        :sensoryValue          "2.0"^^xsd:double .
-
 :000142-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Armagnac pairing" ;
         :hasKeyIngredient      :000142 ;
@@ -15495,10 +15518,19 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001959 ;
         :matchScore            "0.0211864411830902"^^xsd:double .
 
-:fatty_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "fatty_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :green .
+:fatty_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "fatty_aroma"@en ;
+        :hasAromaType   :green .
+
+:c253018f-7609-441c-9452-2fab68e6fec2
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :mustard_aroma ;
+        :sensoryValue          "5.25"^^xsd:double .
+
+:c5e3ebb2-2e10-4127-a23d-65858c18fec5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "8.5"^^xsd:double .
 
 :000144-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Mustard pairing" ;
@@ -15548,6 +15580,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.0491283684968948"^^xsd:double .
 
+:5e582466-d7f3-4a36-9b82-5da7c33af482
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pine_aroma ;
+        :sensoryValue          "0.9"^^xsd:double .
+
 :006471-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Carrot with Lime pairing" ;
         :hasKeyIngredient      :006471 ;
@@ -15594,11 +15631,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :006473 ;
         :hasRelatedIngredient  :001218 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
-
-:4b5e4e23-a35a-48d2-8770-d4dc310f354d
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.07500000000000001"^^xsd:double .
 
 :003290-006002  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Pasta pairing" ;
@@ -15691,11 +15723,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.333333343267441"^^xsd:double .
 
-:703efc1e-5e4c-4811-a4f7-6b8c5ffd7174
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :creamy_aroma ;
-        :sensoryValue          "0.6"^^xsd:double .
-
 :000355-000110  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Leek pairing" ;
         :hasKeyIngredient      :000355 ;
@@ -15706,11 +15733,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q41778389"^^xsd:anyURI ;
         skos:definition         "A variety of apple known for their crisp texture and sweet-tart flavor, commonly eaten fresh."@en ;
         skos:prefLabel          "Apple 'Jonagold'"@en ;
-        :hasAroma               :208ce257-6f3c-47da-ae4b-ece622f38e77 , :46bdf81d-5bc3-4fbe-8902-c615c77c346c , :2ac6f933-440f-4c9a-860a-14176dd796f9 ;
+        :hasAroma               :6456654b-dcad-4281-8b60-78e1fee4a6f9 , :d55e5d76-db91-4b26-a202-cd772e05e3de , :4af5b46b-8093-46d7-a19b-399e5426c351 ;
         :hasFunctionalBenefit   :Satiety , :Probiotic , :Diabetic , :Cardiovascular , :Sleep , :Bone , :Prebiotic , :Brain , :Weight-loss , :Ageing , :Digestion , :Stress , :Antioxidant , :Weight-gain , :Energy , :Antibacterial , :Immunity ;
         :hasIngredientCategory  :icat:000091 ;
-        :hasTaste               :efff6ca5-62b8-4ba7-8eb3-df8feaea97db , :d053849f-89d5-4a1d-a3f3-7208499d51c8 ;
-        :hasTexture             :8087ea38-e506-4cc5-8cdc-140866e5efd6 .
+        :hasTaste               :580d66af-0452-4070-b56d-c8485b9d8782 , :f7656fb3-7ed5-40a6-8c4b-dd4e63e8dd6c ;
+        :hasTexture             :cc03e435-c362-4be0-b68c-14e8cb467cb4 .
 
 :000887-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Mayonnaise pairing" ;
@@ -15753,6 +15780,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000091 ;
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.5"^^xsd:double .
+
+:c21418e8-1d58-4d6e-a3a6-70e5fd4e16e6
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :floral_aroma ;
+        :sensoryValue          "5.25"^^xsd:double .
 
 :000149-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Sweet Cherry pairing" ;
@@ -15813,11 +15845,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :000161 ;
         :matchScore            "0.280000001192093"^^xsd:double .
-
-:12221a67-3116-4194-92ea-bf6d48a1c19b
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "0.2"^^xsd:double .
 
 :000117-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Sweet Cherry pairing" ;
@@ -16017,11 +16044,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000357 ;
         :matchScore            "0.306711196899414"^^xsd:double .
 
-:7a73dd1a-3117-44c4-9e96-89ec9b11e806
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :garlic_aroma ;
-        :sensoryValue          "48.0"^^xsd:double .
-
 :icat:000112  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000021 ;
         skos:definition  "Encompasses snack foods made from rice, such as rice cakes, rice crackers, or puffed rice snacks, often flavored or seasoned."@en ;
@@ -16038,6 +16060,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000040 ;
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.545454561710358"^^xsd:double .
+
+:e67e5c22-4a35-40b8-b3e6-afbedc8e7b0f
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
+:adfe6de9-5747-4689-8566-639e3d7a8a6b
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :egg_aroma ;
+        :sensoryValue          "6.0"^^xsd:double .
 
 :003143-001218  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Cod pairing" ;
@@ -16098,11 +16130,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :006002 ;
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.617021262645721"^^xsd:double .
-
-:714eb6cf-e59e-4fef-b755-21817f754187
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :banana_aroma ;
-        :sensoryValue          "36.0"^^xsd:double .
 
 :000452-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Baguette pairing" ;
@@ -16210,6 +16237,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:broader     :icat:000015 ;
         skos:definition  "Encompasses herbs used primarily for cooking and flavoring dishes, such as basil, thyme, rosemary, and parsley."@en ;
         skos:prefLabel   "Culinary Herbs"@en .
+
+:4d96f0f0-26ca-4c8a-b4d9-b9fbd41f5003
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :milk_aroma ;
+        :sensoryValue          "5.0"^^xsd:double .
+
+:ef0c7d6e-3f3d-41d2-b1e2-c692c5935c03
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :mushroom_aroma ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :Digestion  rdf:type     :FunctionalBenefit ;
         skos:definition  "Involve ingredients or products that aid in the breakdown and absorption of nutrients in the digestive tract." ;
@@ -16365,21 +16402,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000096 ;
         :matchScore            "0.476190477609634"^^xsd:double .
 
-:c890b04f-f230-44b6-9220-52c0570a0bce
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "0.45"^^xsd:double .
-
 :001696-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grape with Gruyère pairing" ;
         :hasKeyIngredient      :001696 ;
         :hasRelatedIngredient  :000107 ;
         :matchScore            "0.0405405387282372"^^xsd:double .
-
-:208ce257-6f3c-47da-ae4b-ece622f38e77
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.375"^^xsd:double .
 
 :000413-000141  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Apple 'Jonagold' with Yellow Peach pairing" ;
@@ -16438,6 +16465,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000149 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.368098169565201"^^xsd:double .
+
+:953918d1-47b7-4ddf-b679-bd1156268f8a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pungent_aroma ;
+        :sensoryValue          "2.1"^^xsd:double .
 
 :000313-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Armagnac pairing" ;
@@ -16521,15 +16553,15 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q61858403"^^xsd:anyURI ;
         skos:definition         "A sweet and aromatic fruit with orange flesh, commonly eaten fresh or used in salads."@en ;
         skos:prefLabel          "Cantaloupe Melon"@en ;
-        :hasAroma               :f434d3d5-282d-441c-908e-d8b1a3122051 , :dc0fb51d-7958-411f-9799-b7032888f06f , :a15354bd-c85e-43d9-a386-12b00fd8d762 , :1985830b-e3f8-47b2-8adf-c8efddd1fcab ;
+        :hasAroma               :bf5b2dc7-10c4-416a-a41e-82f713762ce7 , :b9f405f4-e20b-4ddb-a22e-0d581ecab731 , :c9d4266d-48f3-4cbb-ab90-a465772d5c57 , :fc09d9e6-fcbc-43cc-92ef-d1037741a940 ;
         :hasFunctionalBenefit   :Stress ;
         :hasIngredientCategory  :icat:000090 ;
-        :hasTaste               :12221a67-3116-4194-92ea-bf6d48a1c19b , :b0c72508-ba0b-4b09-aab2-99f1102c562e .
+        :hasTaste               :385def65-9d6c-47d5-9256-6b4b69771ef3 , :a86a9034-e7a7-44ff-97bf-413eed7fa130 .
 
-:9a347455-987b-45b9-bc58-99ec15e4c45e
+:d55e5d76-db91-4b26-a202-cd772e05e3de
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :rose_aroma ;
-        :sensoryValue          "2.5"^^xsd:double .
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "2.6999999999999997"^^xsd:double .
 
 :000163-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Avocado pairing" ;
@@ -16560,11 +16592,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000104 ;
         :hasRelatedIngredient  :000313 ;
         :matchScore            "0.113207548856735"^^xsd:double .
-
-:96c93d23-a868-4e70-b48a-e7c6f14fc463
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :fatty_taste ;
-        :sensoryValue          "0.3"^^xsd:double .
 
 :006821-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Pumpkin pairing" ;
@@ -16758,10 +16785,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.241379305720329"^^xsd:double .
 
-:2a930cb6-13e1-4f7f-bf51-7b21afe42d04
+:13f3d699-dbb0-4204-8fdf-e654b01619e1
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :milk_aroma ;
-        :sensoryValue          "3.0"^^xsd:double .
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "0.8500000000000001"^^xsd:double .
 
 :000787-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vanilla 'Bourbon' with Chorizo pairing" ;
@@ -16919,6 +16946,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.0602975711226463"^^xsd:double .
 
+:040dc59a-48df-40b3-b857-a7d945e76955
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :bitter_taste ;
+        :sensoryValue          "2.0"^^xsd:double .
+
 :000181-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Chorizo pairing" ;
         :hasKeyIngredient      :000181 ;
@@ -16985,10 +17017,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.233918130397797"^^xsd:double .
 
-:b1e130dd-2413-48f2-9edf-43d598c35510
+:0f8ffd5e-f69d-4f5a-96c3-2052dbd9495b
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :berry_aroma ;
-        :sensoryValue          "9.5"^^xsd:double .
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "0.03"^^xsd:double .
 
 :000311-000161  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Watermelon pairing" ;
@@ -17013,6 +17045,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001394 ;
         :hasRelatedIngredient  :006821 ;
         :matchScore            "0.12398523837328"^^xsd:double .
+
+:309b6890-9614-4be1-bf89-781e276f5d4f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pungent_aroma ;
+        :sensoryValue          "3.15"^^xsd:double .
 
 :000107-000151  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Gruyère with Pineapple pairing" ;
@@ -17060,6 +17097,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000357 ;
         :matchScore            "0.0475435815751553"^^xsd:double .
 
+:8dedf1d7-f4dd-4488-b13c-62ec498f82d3
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pine_aroma ;
+        :sensoryValue          "1.8"^^xsd:double .
+
 :icat:000015  rdf:type   skos:Concept , :IngredientCategory ;
         skos:definition  "Encompasses culinary and medicinal herbs used for flavoring, garnishing, or as natural remedies."@en ;
         skos:prefLabel   "Herbs Category"@en .
@@ -17075,11 +17117,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000520 ;
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.16153846681118"^^xsd:double .
-
-:9f297a78-2bf6-4510-9f61-5bd8a47ccef2
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :vanilla_aroma ;
-        :sensoryValue          "0.5249999999999999"^^xsd:double .
 
 :000030-003290  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Ginger with Brie pairing" ;
@@ -17148,11 +17185,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
 :vegetable  rdf:type    :AromaType ;
         skos:prefLabel  "vegetable"@en .
 
-:6ebe1cc2-403f-4154-b017-bf19ead5c20a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "7.2"^^xsd:double .
-
 :000887-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Yellow Grapefruit pairing" ;
         :hasKeyIngredient      :000887 ;
@@ -17175,10 +17207,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q167893"^^xsd:anyURI ;
         skos:definition         "Creamy condiment made from eggs, oil, and vinegar or lemon juice, commonly used in salads and sandwiches."@en ;
         skos:prefLabel          "Mayonnaise"@en ;
-        :hasAroma               :f14ec2fb-0cc0-4e2d-a347-a2a91fed5a31 , :3d568837-f4a7-4d84-bc31-031b1eb66733 , :562a71a1-9075-4cf6-a3d8-bfcc28279a9e ;
+        :hasAroma               :21f11285-44ac-4131-9f85-ed7d11049802 , :b90a652c-0be5-41e2-825b-a0277e65fa5e , :e95fa90b-df48-466f-a8d7-c823cee62345 ;
         :hasFunctionalBenefit   :Energy ;
         :hasIngredientCategory  :icat:000040 ;
-        :hasTaste               :9b2097ba-7a6c-48ac-8152-5d2895e94d3e .
+        :hasTaste               :7d2072fd-0803-42b2-9ea2-fb52e8a9cf8b .
 
 :005483-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Cheddar pairing" ;
@@ -17234,6 +17266,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :008970 ;
         :matchScore            "0.181999996304512"^^xsd:double .
 
+:2d85c44b-8afa-465d-a555-8aa9039b4012
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :earthy_aroma ;
+        :sensoryValue          "7.6000000000000005"^^xsd:double .
+
 :001218-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Oyster pairing" ;
         :hasKeyIngredient      :001218 ;
@@ -17252,11 +17289,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.0500834733247757"^^xsd:double .
 
+:269f9416-11bb-40e4-be7a-ee60b5c32924
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.22499999999999998"^^xsd:double .
+
 :000151-000475  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pineapple with Pecan Nut pairing" ;
         :hasKeyIngredient      :000151 ;
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.0111607145518064"^^xsd:double .
+
+:8f27822f-1d09-4a75-8ba9-8a5668959ab0
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "6.0"^^xsd:double .
 
 :000306-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Cheddar pairing" ;
@@ -17354,11 +17401,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000920 ;
         :matchScore            "0.00285714282654226"^^xsd:double .
 
-:1f73c26e-f642-4b9f-b440-c24eb2f32d33
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "0.25"^^xsd:double .
-
 :000096-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chives with Plum pairing" ;
         :hasKeyIngredient      :000096 ;
@@ -17387,7 +17429,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q122195"^^xsd:anyURI ;
         skos:definition         "A type of tequila known for its clear color and pure, unaged flavor."@en ;
         skos:prefLabel          "Tequila Silver"@en ;
-        :hasAroma               :0f289a49-62a8-4e14-bbc7-95ce4c8eea3a , :e3d647d0-edd6-4d0e-9bb2-a4cb772427e0 , :582306d4-06bf-49db-994d-6d347c566e56 , :7bfab38f-985a-4154-ac08-57211e1c271b , :5df5c460-7de7-49ff-8590-f60f5ed7e3f7 , :0436810f-923a-4dab-aeae-f1e4fe060f3b , :6f8e3598-907f-41ff-9be1-340df03c1230 ;
+        :hasAroma               :6c9bf865-eae7-4fc2-a9e5-70a97c6dfbec , :cf18e7c1-93c0-45e1-bd96-d105f310c505 , :237f7d26-ffa8-42dc-99fa-523efd56f8e4 , :e2e63fab-ff74-47f5-ab0f-c588650a91a6 , :9a145baa-c7dd-4722-9d6b-1d1ab8d694f7 , :580bdfdc-a3cd-4291-a482-35f8e1e1a2ff , :0e6a84d8-603f-417b-ab39-521029993852 ;
         :hasIngredientCategory  :icat:000069 .
 
 :000141-000040  rdf:type       :IngredientPairing ;
@@ -17568,21 +17610,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
 
-:7728ddb4-947f-4475-a2f3-6ad636a36350
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :thyme_aroma ;
-        :sensoryValue          "22.4"^^xsd:double .
-
 :001218-000133  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Strawberry pairing" ;
         :hasKeyIngredient      :001218 ;
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.00285714282654226"^^xsd:double .
-
-:e7a3550b-a234-4963-ba6c-900d58c3c602
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :salt_taste ;
-        :sensoryValue          "4.0"^^xsd:double .
 
 :000801-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Milk pairing" ;
@@ -17650,6 +17682,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000021 ;
         :matchScore            "0.00185873603913933"^^xsd:double .
 
+:5d74bf5a-45c9-4a26-b970-7eb939c554b6
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :007105-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Grape pairing" ;
         :hasKeyIngredient      :007105 ;
@@ -17695,11 +17732,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
 :soft_texture  rdf:type  :SensoryDescriptor ;
         skos:prefLabel  "soft_texture"@en .
 
-:5b71e5b2-d983-401d-91a8-92791d0af43a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :ethanol_aroma ;
-        :sensoryValue          "22.0"^^xsd:double .
-
 :005930-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Dark Chocolate pairing" ;
         :hasKeyIngredient      :005930 ;
@@ -17723,6 +17755,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000101 ;
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.379999995231628"^^xsd:double .
+
+:2aa6f95c-f733-43fe-8c47-8a421e5030b3
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :hard_texture ;
+        :sensoryValue          true .
 
 :000031-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemongrass with Milk pairing" ;
@@ -17765,6 +17802,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000181 ;
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.370370358228683"^^xsd:double .
+
+:51cae09a-6e03-483e-8be8-5fc84dd43983
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :beany_aroma ;
+        :sensoryValue          "1.5"^^xsd:double .
 
 :000452-000993  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Tabasco pairing" ;
@@ -17911,11 +17953,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.140000000596046"^^xsd:double .
 
-:aa6b9a4b-7e0d-465c-aee9-444f7cb316d0
-        rdf:type               :Trigeminal ;
-        :hasSensoryDescriptor  :astringent_trigeminal_taste ;
-        :sensoryValue          true .
-
 :003246-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cow Mozzarella with Yellow Grapefruit pairing" ;
         :hasKeyIngredient      :003246 ;
@@ -17970,11 +18007,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.205882355570793"^^xsd:double .
 
-:d74e472f-ba2d-41ad-9fad-88a8f7f96793
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "1.3"^^xsd:double .
-
 :000133-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Armagnac pairing" ;
         :hasKeyIngredient      :000133 ;
@@ -17998,6 +18030,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005754 ;
         :hasRelatedIngredient  :000920 ;
         :matchScore            "0.00507462676614523"^^xsd:double .
+
+:d45b6884-1b31-40fe-95cf-01d71b937fde
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :creamy_texture ;
+        :sensoryValue          true .
 
 :000040-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Green Bean pairing" ;
@@ -18069,9 +18106,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q335016"^^xsd:anyURI ;
         skos:definition         "Tabasco is a brand of hot sauce made from tabasco peppers, commonly used to add heat and flavor to dishes."@en ;
         skos:prefLabel          "Tabasco"@en ;
-        :hasAroma               :ef9cbfee-3758-43d8-840c-5311de286357 , :f54709ba-d50b-4d7d-b34e-cf439231b1f2 , :f95555a6-20c6-48f8-a10f-1567f99adab3 ;
+        :hasAroma               :f6828a39-0dc9-4220-976a-114fef2f7800 , :85406743-5161-4ff4-94e0-c7a152d4927d , :92ae0c09-6cb3-4192-b1ff-0eb5b4426fa7 ;
         :hasIngredientCategory  :icat:000147 ;
-        :hasTaste               :cc2f5ae7-2c4e-4142-a667-81fd86a86961 .
+        :hasTaste               :cf2e4cb9-293a-4394-8773-6bdd2fb22b59 .
 
 :000520-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brussels Sprouts with Hamburger pairing" ;
@@ -18144,15 +18181,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.13621261715889"^^xsd:double .
 
-:51d6e089-6b24-48b0-a57b-741261932aa9
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :starchy_texture ;
-        :sensoryValue          true .
-
 :creamy_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "creamy_aroma"@en ;
-        :aromaIntensity  "2.0"^^xsd:double ;
-        :hasAromaType    :cheesy .
+        skos:prefLabel  "creamy_aroma"@en ;
+        :hasAromaType   :cheesy .
 
 :000355-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Emmentaler pairing" ;
@@ -18418,11 +18449,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000161 ;
         :matchScore            "0.289206355810165"^^xsd:double .
 
-:f372b291-2b1d-4ca8-a2d5-bc7eb7750e05
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cucumber_aroma ;
-        :sensoryValue          "1.65"^^xsd:double .
-
 :003290-000306  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Atlantic Salmon pairing" ;
         :hasKeyIngredient      :003290 ;
@@ -18493,11 +18519,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005569 ;
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.0500000007450581"^^xsd:double .
-
-:83fff77e-ac0e-48f0-ab9e-94d65df3ac19
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :juniper_aroma ;
-        :sensoryValue          "0.1"^^xsd:double .
 
 :000031-001755  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemongrass with Cava pairing" ;
@@ -18599,12 +18620,12 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q21552830"^^xsd:anyURI ;
         skos:definition         "Yellow grapefruits are citrus fruits with a tangy-sweet flavor, commonly eaten fresh or used in juices. Their taste is slightly more bitter when compared to pink and red grapefruit."@en ;
         skos:prefLabel          "Yellow Grapefruit"@en ;
-        :hasAroma               :3f02de85-ba88-43ca-9966-ff2c11c9d1db , :4d24de36-6a76-40bd-861b-470c76ee2504 , :d355da8c-e470-45e5-b0ce-a30345d8975c , :c44bbf61-00bc-4ece-9128-97bd3d23e9e3 ;
+        :hasAroma               :fb4edd76-cc68-4436-8705-7eb1a52d37df , :a0e2e1c6-37cc-44ad-832c-371a24119cbf , :60339205-8777-41f2-8ede-872e79a28a77 , :5e582466-d7f3-4a36-9b82-5da7c33af482 ;
         :hasFunctionalBenefit   :Stress , :Cardiovascular , :Diabetic , :Aromatherapy , :Digestion , :Brain , :Probiotic , :Antioxidant , :Weight-loss , :Bone , :Energy ;
         :hasIngredientCategory  :icat:000089 ;
-        :hasTaste               :34731204-6f1a-4fd8-8b71-a40eb08d5944 , :974b991c-a7e2-4ea7-b156-e17a6cc8a600 , :56baa775-cb94-4c53-9e63-d6a6b0115c55 ;
-        :hasTexture             :4207f25d-7f20-4f05-a561-1c602601641e ;
-        :hasTrigeminal          :d371a504-bba7-4cc2-ac42-712fca46b22a .
+        :hasTaste               :694a0c76-95e9-4ac5-8cd0-278e72f61c4e , :b0d208ac-ba64-4689-970f-7e44babd991c , :040dc59a-48df-40b3-b857-a7d945e76955 ;
+        :hasTexture             :87d473fd-4479-4664-9bd5-7306809b7d34 ;
+        :hasTrigeminal          :16293514-d036-414e-9fc4-1331d1de00d1 .
 
 :000801-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Lime pairing" ;
@@ -18665,10 +18686,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.259740263223648"^^xsd:double .
 
-:1985830b-e3f8-47b2-8adf-c8efddd1fcab
+:059f08d7-7414-4ed1-be9e-384b571cc420
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "4.5"^^xsd:double .
+        :hasSensoryDescriptor  :rose_aroma ;
+        :sensoryValue          "2.0"^^xsd:double .
 
 :000472-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Green Bean pairing" ;
@@ -18688,6 +18709,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.204678356647491"^^xsd:double .
 
+:8e1d68ce-aab8-4436-95f2-92af91090e3c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :thyme_aroma ;
+        :sensoryValue          "22.4"^^xsd:double .
+
 :000104-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Milk pairing" ;
         :hasKeyIngredient      :000104 ;
@@ -18705,6 +18731,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001959 ;
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.538461565971375"^^xsd:double .
+
+:70df6f35-2b77-4756-b5d6-f0bcf4baefaa
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
 
 :000078-000161  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Watermelon pairing" ;
@@ -18802,16 +18833,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000163 ;
         :matchScore            "0.181818187236786"^^xsd:double .
 
-:ecbfd8c4-e6ca-4148-9bb4-b913c3e33132
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "0.2"^^xsd:double .
-
-:4bf77b47-b348-4841-bfb7-b80073442562
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "1.25"^^xsd:double .
-
 :001755-000475  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Pecan Nut pairing" ;
         :hasKeyIngredient      :001755 ;
@@ -18883,6 +18904,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.0409356728196144"^^xsd:double .
 
+:5a926eaa-71fb-44bb-965f-50ab96648787
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :acidic_aroma ;
+        :sensoryValue          "1.05"^^xsd:double .
+
 :000021-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Veal pairing" ;
         :hasKeyIngredient      :000021 ;
@@ -18913,16 +18939,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000472 ;
         :matchScore            "0.0174825172871351"^^xsd:double .
 
+:c87cc514-f4ed-4a4b-9083-c7a059dd84fc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :melon_aroma ;
+        :sensoryValue          "1.7999999999999998"^^xsd:double .
+
 :000078-001218  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Cod pairing" ;
         :hasKeyIngredient      :000078 ;
         :hasRelatedIngredient  :001218 ;
         :matchScore            "0.0588235296308994"^^xsd:double .
 
-:c44bbf61-00bc-4ece-9128-97bd3d23e9e3
+:2062884a-2810-4945-bc84-97984efd20f9
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :grapefruit_aroma ;
-        :sensoryValue          "3.75"^^xsd:double .
+        :hasSensoryDescriptor  :cucumber_aroma ;
+        :sensoryValue          "33.0"^^xsd:double .
 
 :000215-000252  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Sweet Potato pairing" ;
@@ -19001,6 +19032,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000840 ;
         :hasRelatedIngredient  :000515 ;
         :matchScore            "0.0185185186564922"^^xsd:double .
+
+:48566181-02e5-43c3-b4f8-5d9a7389f60b
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :celery_aroma ;
+        :sensoryValue          "22.0"^^xsd:double .
 
 :005760-000021  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Fish Sauce pairing" ;
@@ -19103,10 +19139,14 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000123 ;
         :matchScore            "0.113924048841"^^xsd:double .
 
-:pine_aroma  rdf:type    :SensoryDescriptor ;
-        skos:prefLabel   "pine_aroma"@en ;
-        :aromaIntensity  "4.5"^^xsd:double ;
-        :hasAromaType    :woody .
+:pine_aroma  rdf:type   :SensoryDescriptor ;
+        skos:prefLabel  "pine_aroma"@en ;
+        :hasAromaType   :woody .
+
+:6a7f17c4-87bd-4cff-a914-8c53e8eb58ad
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :mustard_aroma ;
+        :sensoryValue          "31.5"^^xsd:double .
 
 :000059-000161  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Watermelon pairing" ;
@@ -19251,6 +19291,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001755 ;
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.239999994635582"^^xsd:double .
+
+:2e49d59d-44b8-4750-a2ed-374e530a2602
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :roasted_aroma ;
+        :sensoryValue          "0.17500000000000002"^^xsd:double .
 
 :003143-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Chorizo pairing" ;
@@ -19397,9 +19442,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0978856682777405"^^xsd:double .
 
 :coconut_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "coconut_aroma"@en ;
-        :aromaIntensity  "10.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "coconut_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000313-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Mayonnaise pairing" ;
@@ -19573,6 +19617,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000472 ;
         :matchScore            "0.0657894760370255"^^xsd:double .
 
+:a903665b-884b-472d-b028-830684f21644
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.22499999999999998"^^xsd:double .
+
 :000155-001624  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Vodka pairing" ;
         :hasKeyIngredient      :000155 ;
@@ -19657,6 +19706,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000520 ;
         :matchScore            "0.0377121306955814"^^xsd:double .
 
+:384da465-fd13-41c5-ae81-51cd8e8de14f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :creamy_aroma ;
+        :sensoryValue          "2.0"^^xsd:double .
+
 :000876-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Grape pairing" ;
         :hasKeyIngredient      :000876 ;
@@ -19674,6 +19728,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000123 ;
         :hasRelatedIngredient  :001624 ;
         :matchScore            "0.0941176488995552"^^xsd:double .
+
+:da5ded1a-417b-4537-bef2-7a9fa488eff0
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "2.55"^^xsd:double .
 
 :005760-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Milk pairing" ;
@@ -19750,6 +19809,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000182 ;
         :matchScore            "0.0144615387544036"^^xsd:double .
 
+:2d0088c6-7bb8-4d18-af82-bcd63063c191
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :camphor_aroma ;
+        :sensoryValue          "1.4000000000000001"^^xsd:double .
+
 :000161-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with Cheddar pairing" ;
         :hasKeyIngredient      :000161 ;
@@ -19793,9 +19857,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0461836867034435"^^xsd:double .
 
 :hazelnut_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "hazelnut_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :nutty .
+        skos:prefLabel  "hazelnut_aroma"@en ;
+        :hasAromaType   :nutty .
 
 :000213-000014  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Boiled Egg pairing" ;
@@ -19833,10 +19896,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000151 ;
         :matchScore            "0.177714288234711"^^xsd:double .
 
-:83e72a66-2c8b-4847-9d85-00e622e753a7
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "0.5"^^xsd:double .
+:237f7d26-ffa8-42dc-99fa-523efd56f8e4
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :smoky_aroma ;
+        :sensoryValue          "1.5"^^xsd:double .
 
 :000791-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Hamburger pairing" ;
@@ -19898,11 +19961,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.0803986713290215"^^xsd:double .
 
-:c84dc400-1c48-4343-9731-40272ed22412
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "4.0"^^xsd:double .
-
 :005842-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Calvados pairing" ;
         :hasKeyIngredient      :005842 ;
@@ -19949,10 +20007,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.1840490847826"^^xsd:double .
 
-:5df5c460-7de7-49ff-8590-f60f5ed7e3f7
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :herbal_aroma ;
-        :sensoryValue          "1.4000000000000001"^^xsd:double .
+:51ff66d8-ddfd-4fc6-bd51-87ecc18c8c45
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
 
 :005569-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pear with Basil Leaf pairing" ;
@@ -19977,11 +20035,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005545 ;
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.216666668653488"^^xsd:double .
-
-:2ee333bf-938e-4205-bcb3-61283e5f7351
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :milk_aroma ;
-        :sensoryValue          "2.0"^^xsd:double .
 
 :000215-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Lime pairing" ;
@@ -20024,6 +20077,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000117 ;
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.385964900255203"^^xsd:double .
+
+:1193764b-7cae-47d8-a53a-358e27021cb2
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "0.45"^^xsd:double .
 
 :000104-000017  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Tomato pairing" ;
@@ -20126,11 +20184,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001624 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0487341769039631"^^xsd:double .
-
-:bca8bd1e-928f-4a89-8bfa-83949e3d749b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :mushroom_aroma ;
-        :sensoryValue          "3.0"^^xsd:double .
 
 :005675-000151  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Pineapple pairing" ;
@@ -20239,22 +20292,27 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:definition  "Includes vegetables where the stem or stalk portion is consumed, such as asparagus, celery, or rhubarb."@en ;
         skos:prefLabel   "Stem Vegetables"@en .
 
+:f7ede252-920e-4bee-9740-436ee60cdf72
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :honey_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :000149-001624  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Vodka pairing" ;
         :hasKeyIngredient      :000149 ;
         :hasRelatedIngredient  :001624 ;
         :matchScore            "0.0736196339130402"^^xsd:double .
 
-:c5ca6f27-d54a-44d4-b8a5-49838db2124a
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
-
 :000355-003290  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Brie pairing" ;
         :hasKeyIngredient      :000355 ;
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.241379305720329"^^xsd:double .
+
+:f7cf8e9b-c53f-4e56-82fa-849f611df559
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :orange_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000787-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vanilla 'Bourbon' with Acacia Honey pairing" ;
@@ -20340,6 +20398,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000181 ;
         :matchScore            "0.0166666675359011"^^xsd:double .
 
+:87b8e806-dbf2-4836-a892-85cd384cb417
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "0.2"^^xsd:double .
+
 :000163-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Orange pairing" ;
         :hasKeyIngredient      :000163 ;
@@ -20351,11 +20414,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005569 ;
         :hasRelatedIngredient  :005675 ;
         :matchScore            "0.00357142859138548"^^xsd:double .
-
-:b1972eec-4644-4ebe-aa84-f53cf0fd001a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :woody_aroma ;
-        :sensoryValue          "0.5"^^xsd:double .
 
 :005760-000059  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Cauliflower pairing" ;
@@ -20417,10 +20475,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.00769230769947171"^^xsd:double .
 
-:923af0a4-8363-4658-9420-8f8ae0dfe11d
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :apple_aroma ;
-        :sensoryValue          "9.1"^^xsd:double .
+:0b453379-fda4-4656-8c81-ab0ce1a3de9e
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "3.2"^^xsd:double .
 
 :000357-000840  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with London Dry Gin pairing" ;
@@ -20463,6 +20521,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007109 ;
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.315789461135864"^^xsd:double .
+
+:544ad1a6-518f-455e-878b-45dd7431d85c
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :bitter_taste ;
+        :sensoryValue          "0.1"^^xsd:double .
 
 :000791-000313  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Honey pairing" ;
@@ -20542,6 +20605,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.238095238804817"^^xsd:double .
 
+:43353cb4-bca7-48d3-b073-36295a9f8e51
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.07500000000000001"^^xsd:double .
+
 :000055-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Humulus Shoot pairing" ;
         :hasKeyIngredient      :000055 ;
@@ -20566,6 +20634,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000144 ;
         :matchScore            "0.025000000372529"^^xsd:double .
 
+:1c339b73-3a3c-4644-be98-897cb5426648
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :roasted_aroma ;
+        :sensoryValue          "0.525"^^xsd:double .
+
 :icat:000131  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000025 ;
         skos:definition  "Encompasses various edible fungi, including mushrooms, truffles, and other types of fungi used in culinary preparations."@en ;
@@ -20576,11 +20649,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000149 ;
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.12269938737154"^^xsd:double .
-
-:61d506e1-68d5-4426-9650-97fac890c52a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :buttery_aroma ;
-        :sensoryValue          "0.6749999999999999"^^xsd:double .
 
 :matchScore  rdf:type    owl:DatatypeProperty ;
         rdfs:domain      :IngredientPairing ;
@@ -20660,6 +20728,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000110 ;
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.300000011920929"^^xsd:double .
+
+:22448e58-725d-405a-8eb5-5f72ee8c4fa7
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :rose_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :005842-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Yellow Nectarine pairing" ;
@@ -20839,16 +20912,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.119999997317791"^^xsd:double .
 
-:f366fbbe-4d84-4c69-ae34-952c6c125286
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :hard_texture ;
-        :sensoryValue          true .
-
-:46bdf81d-5bc3-4fbe-8902-c615c77c346c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "2.6999999999999997"^^xsd:double .
-
 :000161-005545  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with Mussel pairing" ;
         :hasKeyIngredient      :000161 ;
@@ -20939,11 +21002,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000938 ;
         :matchScore            "0.0804525464773178"^^xsd:double .
 
-:e679a9c2-c73d-4903-957b-373781b169b8
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :peach_aroma ;
-        :sensoryValue          "22.4"^^xsd:double .
-
 :000109-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Spinach pairing" ;
         :hasKeyIngredient      :000109 ;
@@ -20995,11 +21053,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.0117647061124444"^^xsd:double .
 
-:c8ae8836-606f-4850-b185-a34335e55568
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
-
 :000091-001968  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chervil with Pastis pairing" ;
         :hasKeyIngredient      :000091 ;
@@ -21012,16 +21065,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.241520464420319"^^xsd:double .
 
+:33107666-10b6-4393-a4c5-79a274dc099c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cocoa_aroma ;
+        :sensoryValue          "1.5"^^xsd:double .
+
 :000149-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Cheddar pairing" ;
         :hasKeyIngredient      :000149 ;
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.0981595069169998"^^xsd:double .
-
-:efff6ca5-62b8-4ba7-8eb3-df8feaea97db
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "2.8"^^xsd:double .
 
 :000059-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Orange pairing" ;
@@ -21034,6 +21087,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001448 ;
         :hasRelatedIngredient  :007109 ;
         :matchScore            "0.249315068125725"^^xsd:double .
+
+:7216dd0c-b309-45b8-9e2a-6d3a6e0196dc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "0.45"^^xsd:double .
 
 :000840-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "London Dry Gin with Baguette pairing" ;
@@ -21065,6 +21123,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.0555555559694767"^^xsd:double .
 
+:e00d2323-c2d8-4f35-8475-7864684e9a54
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
+
 :000452-000887  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with White Chocolate pairing" ;
         :hasKeyIngredient      :000452 ;
@@ -21075,11 +21138,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q23012379"^^xsd:anyURI ;
         skos:definition         "Crisp, green vegetable with a mild, earthy flavor, often used in salads, soups, and as a crunchy snack."@en ;
         skos:prefLabel          "Celery"@en ;
-        :hasAroma               :36f5ec78-28c8-4900-98da-28cb4f9a9cc9 , :b7c693be-9c02-46b3-926d-a5d66d5bfb1a , :c78cb184-2d5b-4372-9c07-821d59641f86 ;
+        :hasAroma               :dd8e67d6-04c9-4419-aa21-48e6a9e65001 , :ea879404-8324-4392-bf95-8bda58db1f93 , :48566181-02e5-43c3-b4f8-5d9a7389f60b ;
         :hasFunctionalBenefit   :Brain , :Vitamins , :Cardiovascular , :Antioxidant , :Energy , :Weight-loss , :Digestion , :Minerals , :Diabetic , :Probiotic ;
         :hasIngredientCategory  :icat:000136 ;
-        :hasTaste               :c686968f-b42b-4abe-ae2f-e9b0daeb8d9d ;
-        :hasTexture             :f9d95e38-db01-405c-9a82-a03b0ba8affe .
+        :hasTaste               :18430806-48a3-4c03-99a5-2998d2bd8b0b ;
+        :hasTexture             :02b08600-786c-4db8-aeea-fd4c38ae7580 .
 
 :006821-001755  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Cava pairing" ;
@@ -21099,10 +21162,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.00175438600126654"^^xsd:double .
 
-:c78cb184-2d5b-4372-9c07-821d59641f86
+:dee4d3b6-7eb1-4aa0-9aac-9860b4eda768
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :potato_aroma ;
-        :sensoryValue          "4.5"^^xsd:double .
+        :hasSensoryDescriptor  :buttery_aroma ;
+        :sensoryValue          "0.6749999999999999"^^xsd:double .
 
 :001959-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grappa with Veal pairing" ;
@@ -21182,10 +21245,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.122807018458843"^^xsd:double .
 
-:maple_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "maple_aroma"@en ;
-        :aromaIntensity  "5.0"^^xsd:double ;
-        :hasAromaType    :caramel .
+:maple_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "maple_aroma"@en ;
+        :hasAromaType   :caramel .
 
 :008970-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brewed Coffee with Chorizo pairing" ;
@@ -21233,6 +21295,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000082 ;
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.119999997317791"^^xsd:double .
+
+:11c32709-5179-475c-b22f-805965b5f97e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "1.7000000000000002"^^xsd:double .
 
 :005760-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Calvados pairing" ;
@@ -21318,11 +21385,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.245383724570274"^^xsd:double .
 
-:f5930bd4-b4ed-46b7-a91d-924fe7f0cb17
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :milk_aroma ;
-        :sensoryValue          "6.0"^^xsd:double .
-
 :001696-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grape with Mayonnaise pairing" ;
         :hasKeyIngredient      :001696 ;
@@ -21347,10 +21409,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.1875"^^xsd:double .
 
-:6f8e3598-907f-41ff-9be1-340df03c1230
+:c3a666a5-3014-45e3-a416-400360266306
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :earthy_aroma ;
-        :sensoryValue          "0.9500000000000001"^^xsd:double .
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "0.6000000000000001"^^xsd:double .
 
 :000104-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Green Bean pairing" ;
@@ -21388,6 +21450,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.0170212760567665"^^xsd:double .
 
+:1ce9c3ab-8328-43e1-8417-69ad9eb960b3
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "3.5"^^xsd:double .
+
 :000452-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Brussels Sprouts pairing" ;
         :hasKeyIngredient      :000452 ;
@@ -21405,14 +21472,19 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.0571428574621677"^^xsd:double .
 
+:283a5a72-44b4-4ed7-b24c-54680bfe5f9f
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :hard_texture ;
+        :sensoryValue          true .
+
 :000887  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q742385"^^xsd:anyURI ;
         skos:definition         "A creamy confection made from cocoa butter, sugar, and milk solids, known for its sweet and rich flavor."@en ;
         skos:prefLabel          "White Chocolate"@en ;
-        :hasAroma               :81376944-99a4-4056-8e38-e76e4928e27b , :9f297a78-2bf6-4510-9f61-5bd8a47ccef2 , :346c8448-4516-46a8-85a1-54ee59a54f65 , :45ae2126-e543-4fab-8246-0847284063f9 ;
+        :hasAroma               :cc3ce379-5e2d-4fa7-a3d1-af96664a6979 , :6f9542c8-8e99-44bf-a5bf-77f96f1e77b3 , :33107666-10b6-4393-a4c5-79a274dc099c , :7eedec64-a5e1-4191-92d3-b146038c2d66 ;
         :hasFunctionalBenefit   :Antioxidant , :Energy , :Stress ;
         :hasIngredientCategory  :icat:000004 ;
-        :hasTaste               :99a2bcb6-528f-4e00-a250-f20c718e0976 .
+        :hasTaste               :1ce9c3ab-8328-43e1-8417-69ad9eb960b3 .
 
 :000313-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Pea pairing" ;
@@ -21444,10 +21516,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.0111111113801599"^^xsd:double .
 
-:rose_aroma  rdf:type    :SensoryDescriptor ;
-        skos:prefLabel   "rose_aroma"@en ;
-        :aromaIntensity  "5.0"^^xsd:double ;
-        :hasAromaType    :floral .
+:rose_aroma  rdf:type   :SensoryDescriptor ;
+        skos:prefLabel  "rose_aroma"@en ;
+        :hasAromaType   :floral .
 
 :005675-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Dark Chocolate pairing" ;
@@ -21616,16 +21687,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:definition  "Encompasses various types of noodles and pasta products made from wheat flour, water, and sometimes eggs."@en ;
         skos:prefLabel   "Pasta"@en .
 
-:4bd8e88e-9d3b-4e61-89a9-714b51119615
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "0.6000000000000001"^^xsd:double .
-
-:20a162c2-402e-4eab-8dcc-1c1c00044bdf
-        rdf:type               :Trigeminal ;
-        :hasSensoryDescriptor  :cooling_trigeminal_taste ;
-        :sensoryValue          true .
-
 :000887-000938  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with White Asparagus pairing" ;
         :hasKeyIngredient      :000887 ;
@@ -21686,6 +21747,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.186172217130661"^^xsd:double .
 
+:58b09313-6b3a-4d7e-8a65-10831d3457fb
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "3.2"^^xsd:double .
+
 :001218-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Orange pairing" ;
         :hasKeyIngredient      :001218 ;
@@ -21721,6 +21787,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:definition         "Small, green cruciferous vegetables with a mild, nutty flavor, commonly used in side dishes."@en ;
         skos:prefLabel          "Brussels Sprouts"@en ;
         :hasIngredientCategory  :icat:000130 .
+
+:8a1cf927-b40e-4511-9983-8ea96e8969af
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "0.9"^^xsd:double .
 
 :000078-000110  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Leek pairing" ;
@@ -21758,6 +21829,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001448 ;
         :matchScore            "0.0700483098626137"^^xsd:double .
 
+:b9f405f4-e20b-4ddb-a22e-0d581ecab731
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :floral_aroma ;
+        :sensoryValue          "0.7000000000000001"^^xsd:double .
+
 :005942-000014  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Boiled Egg pairing" ;
         :hasKeyIngredient      :005942 ;
@@ -21788,6 +21864,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.118095241487026"^^xsd:double .
 
+:94429cec-390c-4037-a727-8a763c8864b5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :almond_aroma ;
+        :sensoryValue          "1.3499999999999999"^^xsd:double .
+
 :000096-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chives with Baguette pairing" ;
         :hasKeyIngredient      :000096 ;
@@ -21799,11 +21880,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001448 ;
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.150739729404449"^^xsd:double .
-
-:7512d918-74df-422c-82f6-78ee15465223
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :starchy_texture ;
-        :sensoryValue          true .
 
 :000107-000133  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Gruyère with Strawberry pairing" ;
@@ -21967,9 +22043,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.00111111113801599"^^xsd:double .
 
 :ethanol_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "ethanol_aroma"@en ;
-        :aromaIntensity  "10.0"^^xsd:double ;
-        :hasAromaType    :chemical .
+        skos:prefLabel  "ethanol_aroma"@en ;
+        :hasAromaType   :chemical .
 
 :001696-006002  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grape with Pasta pairing" ;
@@ -22007,21 +22082,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.293333321809769"^^xsd:double .
 
-:b36553aa-db4b-4126-87a9-400ab244ac4d
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "0.45"^^xsd:double .
-
 :000873-000091  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Chervil pairing" ;
         :hasKeyIngredient      :000873 ;
         :hasRelatedIngredient  :000091 ;
         :matchScore            "0.0506329126656055"^^xsd:double .
-
-:e1c2c1ac-674b-4366-8531-b6585b7befb9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :orange_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
 
 :000306-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Pumpkin pairing" ;
@@ -22034,11 +22099,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000142 ;
         :hasRelatedIngredient  :005675 ;
         :matchScore            "0.00806451588869095"^^xsd:double .
-
-:2effeb6e-2dca-4d4e-a7ee-995d440e27da
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :orange_aroma ;
-        :sensoryValue          "0.25"^^xsd:double .
 
 :000046-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Spinach pairing" ;
@@ -22147,11 +22207,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000144 ;
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.0951456278562546"^^xsd:double .
-
-:8280ff28-200f-42b7-a01c-7f6ce3b75849
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :garlic_aroma ;
-        :sensoryValue          "16.0"^^xsd:double .
 
 :000017-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tomato with Sweet Cherry pairing" ;
@@ -22345,6 +22400,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000993 ;
         :matchScore            "0.00990098994225264"^^xsd:double .
 
+:40d415d8-f6dd-459a-bfd3-ade5f8b6fe44
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.025"^^xsd:double .
+
 :005545-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mussel with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :005545 ;
@@ -22492,16 +22552,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000520 ;
         :matchScore            "0.0625"^^xsd:double .
 
-:321f94f1-30e0-489c-aa68-4ed2c465ccbe
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :orange_aroma ;
-        :sensoryValue          "1.25"^^xsd:double .
-
 :000840  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q62076228"^^xsd:anyURI ;
         skos:definition         "A type of gin known for its dry and juniper-forward flavor, commonly used in cocktails."@en ;
         skos:prefLabel          "London Dry Gin"@en ;
-        :hasAroma               :b7f9c3e5-aee7-4e51-b086-bf161705f408 , :a7ddd041-10a1-4e21-bc3f-16a3d29dd156 , :bd17648c-1a6a-4144-8d86-bb74e4377924 , :eb091a25-7fe1-4ded-b68d-2c04d42cf670 , :83fff77e-ac0e-48f0-ab9e-94d65df3ac19 , :7aaa7f32-95cd-4d69-9295-22d2557a2b50 ;
+        :hasAroma               :9f936618-6c1f-444e-b5eb-58813e237ba1 , :10fe6660-d4fe-4abf-9dd1-6b24022905df , :1f9b3e8e-0f49-4d7c-9739-f22e37eb6893 , :92be6278-d122-413c-bb3d-11b6957730f3 , :28672bd8-fb5e-4b61-a65e-5047369da334 , :2d0088c6-7bb8-4d18-af82-bcd63063c191 ;
         :hasIngredientCategory  :icat:000070 .
 
 :000090-006821  rdf:type       :IngredientPairing ;
@@ -22642,10 +22697,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003246 ;
         :matchScore            "0.131147533655167"^^xsd:double .
 
-:melon_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "melon_aroma"@en ;
-        :aromaIntensity  "6.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+:melon_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "melon_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000215-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Basil Leaf pairing" ;
@@ -22731,10 +22785,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.333333343267441"^^xsd:double .
 
-:6694a3fe-3b19-4da4-b8a4-99dd5faec7c0
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
+:8021273f-eca8-403a-8216-2823122bb17f
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "1.5"^^xsd:double .
 
 :000136-000104  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Goat Cheese pairing" ;
@@ -22759,27 +22813,22 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006821 ;
         :matchScore            "0.216455698013306"^^xsd:double .
 
-:d4952150-6524-4c73-af9b-361b56ae9049
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.07500000000000001"^^xsd:double .
-
 :000136-001008  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Milk Chocolate pairing" ;
         :hasKeyIngredient      :000136 ;
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.0439035072922707"^^xsd:double .
 
-:7329d88c-5160-4d4e-b50a-5c34b094d9e1
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000101-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Emmentaler with Cheddar pairing" ;
         :hasKeyIngredient      :000101 ;
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.47299998998642"^^xsd:double .
+
+:683c17a3-95c6-4df9-9a0d-003cf03ebfb0
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "3.5"^^xsd:double .
 
 :000144-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Grape pairing" ;
@@ -22799,6 +22848,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000357 ;
         :matchScore            "0.0996677726507187"^^xsd:double .
 
+:46ab4dad-a191-4215-9b04-d4f56c4b4584
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pungent_aroma ;
+        :sensoryValue          "2.1"^^xsd:double .
+
 :000791-000151  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Pineapple pairing" ;
         :hasKeyIngredient      :000791 ;
@@ -22810,11 +22864,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000096 ;
         :hasRelatedIngredient  :007170 ;
         :matchScore            "0.00999999977648258"^^xsd:double .
-
-:8de3a1e9-f646-4798-9659-3011e7772862
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fishy_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
 
 :005930-002530  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Bread pairing" ;
@@ -22852,10 +22901,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.0500000007450581"^^xsd:double .
 
-:dc4f0864-2f81-474a-8604-1d5d728570b0
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :creamy_texture ;
-        :sensoryValue          true .
+:9f936618-6c1f-444e-b5eb-58813e237ba1
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :juniper_aroma ;
+        :sensoryValue          "0.1"^^xsd:double .
 
 :005675-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Green Bean pairing" ;
@@ -22880,6 +22929,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000215 ;
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.0555555559694767"^^xsd:double .
+
+:214643c4-3772-42fc-a206-35b44e479bc1
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :onion_aroma ;
+        :sensoryValue          "4.8"^^xsd:double .
 
 :000452-000938  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with White Asparagus pairing" ;
@@ -22941,6 +22995,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.644414186477661"^^xsd:double .
 
+:1dbe9cb3-d6cb-4c1b-bf1c-8b82a0bbd568
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "3.75"^^xsd:double .
+
 :000311-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :000311 ;
@@ -23001,11 +23060,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.13199245929718"^^xsd:double .
 
-:e2a05a4f-4189-4524-8fda-da29de1dbde4
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "1.8"^^xsd:double .
-
 :001624-000149  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vodka with Banana pairing" ;
         :hasKeyIngredient      :001624 ;
@@ -23029,11 +23083,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000515 ;
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.200000002980232"^^xsd:double .
-
-:8c342af8-a06d-4277-99c2-305240a8daf7
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :mushroom_aroma ;
-        :sensoryValue          "0.5"^^xsd:double .
 
 :000110-000133  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Leek with Strawberry pairing" ;
@@ -23095,11 +23144,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000017 ;
         :matchScore            "0.0964444428682327"^^xsd:double .
 
-:c6793d4f-139e-4c69-9981-1d13a09d680a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :woody_aroma ;
-        :sensoryValue          "0.15"^^xsd:double .
-
 :000090-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Red Bell Pepper pairing" ;
         :hasKeyIngredient      :000090 ;
@@ -23117,6 +23161,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000031 ;
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.0933333337306976"^^xsd:double .
+
+:5929269e-4a86-4100-a876-6c65617e2419
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :anise_aroma ;
+        :sensoryValue          "2.75"^^xsd:double .
+
+:bd4d7060-07ca-4d18-9437-6ea69f75c530
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "5.0"^^xsd:double .
 
 :000281-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Sweet Cherry pairing" ;
@@ -23235,7 +23289,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q22806705"^^xsd:anyURI ;
         skos:definition         "White asparagus is a milder, sweeter variety of asparagus with pale stalks, commonly enjoyed steamed or roasted as a delicacy."@en ;
         skos:prefLabel          "White Asparagus"@en ;
-        :hasAroma               :b23a4b03-5488-4a5b-9489-a2ee3bdce450 , :d8b76843-22fd-4045-8f01-19c06fb9d845 ;
+        :hasAroma               :5849dad0-a53a-4f50-9142-128afb71719f , :4632a11e-5819-4cb3-bca4-1617b351c94d ;
         :hasIngredientCategory  :icat:000136 .
 
 :000920-006821  rdf:type       :IngredientPairing ;
@@ -23292,15 +23346,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.205882355570793"^^xsd:double .
 
-:c856dfec-4e70-45c7-9d3e-172c6bc10994
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.025"^^xsd:double .
-
 :banana_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "banana_aroma"@en ;
-        :aromaIntensity  "6.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "banana_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :001218-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Chorizo pairing" ;
@@ -23435,9 +23483,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.00851063802838326"^^xsd:double .
 
 :caramel_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "caramel_aroma"@en ;
-        :aromaIntensity  "2.25"^^xsd:double ;
-        :hasAromaType    :caramel .
+        skos:prefLabel  "caramel_aroma"@en ;
+        :hasAromaType   :caramel .
 
 :006002-001008  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pasta with Milk Chocolate pairing" ;
@@ -23498,6 +23545,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000413 ;
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.136363640427589"^^xsd:double .
+
+:03de19dd-4a2f-444e-9d9f-6bb841e6d359
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
 
 :000110-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Leek with Avocado pairing" ;
@@ -23774,6 +23826,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000123 ;
         :matchScore            "0.0129870129749179"^^xsd:double .
 
+:2ce407a1-746a-40f8-b842-f0031fb8b0ce
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
 :000109-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :000109 ;
@@ -23815,11 +23872,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000109 ;
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.0255086552351713"^^xsd:double .
-
-:bcda0e07-34ed-40af-92eb-17267798fa0c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :nutty_aroma ;
-        :sensoryValue          "0.22499999999999998"^^xsd:double .
 
 :008970-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brewed Coffee with Champignon Mushroom pairing" ;
@@ -23868,11 +23920,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :007109 ;
         :matchScore            "0.340000003576279"^^xsd:double .
-
-:9c83c232-3b34-458e-a73a-a71023c82eee
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "4.5"^^xsd:double .
 
 :005842-001394  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Popcorn pairing" ;
@@ -23932,10 +23979,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q5812410"^^xsd:anyURI ;
         skos:definition         "Blueberries are small, round, and dark blue berries known for their sweet and slightly tart taste."@en ;
         skos:prefLabel          "Blueberry"@en ;
-        :hasAroma               :8c489009-02dd-48f9-b033-9bf0dbda9d48 , :923af0a4-8363-4658-9420-8f8ae0dfe11d , :6b89c963-5c5d-4255-860a-825c5d45f888 ;
+        :hasAroma               :baaa3023-f9d9-41eb-97a4-c8769e837235 , :059f08d7-7414-4ed1-be9e-384b571cc420 , :11c32709-5179-475c-b22f-805965b5f97e ;
         :hasFunctionalBenefit   :Cardiovascular , :Antibacterial , :Stress , :Digestion , :Weight-gain , :Bone , :Energy , :Ageing , :Weight-loss , :Vitamins , :Diabetic , :Antioxidant , :Probiotic , :Brain ;
         :hasIngredientCategory  :icat:000088 ;
-        :hasTaste               :a1a376b8-b1f1-4fe8-b669-a20d21aa9347 , :14d534cd-a6b7-47af-9eff-ec86daca2b5c .
+        :hasTaste               :266aa4a9-b30b-4d5a-b40e-bcda3b8f213f , :8021273f-eca8-403a-8216-2823122bb17f .
 
 :000181-003143  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Fourme D'Ambert pairing" ;
@@ -24023,16 +24070,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.290225565433502"^^xsd:double .
 
+:49281643-3db9-4237-bb90-a365e4e4c753
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :milk_aroma ;
+        :sensoryValue          "6.0"^^xsd:double .
+
 :000873-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Green Bean pairing" ;
         :hasKeyIngredient      :000873 ;
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.293670892715454"^^xsd:double .
-
-:95b9f01e-4954-46d8-8e1f-4beabc8c95ef
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :vanilla_aroma ;
-        :sensoryValue          "0.07500000000000001"^^xsd:double .
 
 :000357-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Jasmine Tea pairing" ;
@@ -24044,22 +24091,17 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q81"^^xsd:anyURI ;
         skos:definition         "Crunchy, orange root vegetables with a sweet and earthy flavor, commonly eaten fresh."@en ;
         skos:prefLabel          "Carrot"@en ;
-        :hasAroma               :9a347455-987b-45b9-bc58-99ec15e4c45e , :6ebe1cc2-403f-4154-b017-bf19ead5c20a ;
+        :hasAroma               :5acb8ddf-db40-4f32-9ae5-c4f50a8fa627 , :4eacb6c5-29f5-45b0-bb52-3d49392d8204 ;
         :hasFunctionalBenefit   :Antioxidant , :Prebiotic , :Diabetic , :Cardiovascular , :Digestion , :Satiety , :Bone , :Sleep , :Energy , :Weight-loss , :Probiotic , :Brain , :Minerals , :Vitamins , :Stress ;
         :hasIngredientCategory  :icat:000132 ;
-        :hasTaste               :8c3b3737-05af-4ba0-8984-56ad1aaeb0e8 ;
-        :hasTexture             :f366fbbe-4d84-4c69-ae34-952c6c125286 , :b6ee7575-8b96-45b3-81ea-f442d755c63a .
+        :hasTaste               :4420a489-6bc9-4ee5-bdbb-5a82dd59fbe9 ;
+        :hasTexture             :935cd08c-40ed-4cfd-a8a1-4c1354ac2d75 , :283a5a72-44b4-4ed7-b24c-54680bfe5f9f .
 
 :000311-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Acacia Honey pairing" ;
         :hasKeyIngredient      :000311 ;
         :hasRelatedIngredient  :007105 ;
         :matchScore            "0.241538465023041"^^xsd:double .
-
-:50e8e8b9-5ecc-4a4d-aafd-1f839481cecd
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pungent_aroma ;
-        :sensoryValue          "2.1"^^xsd:double .
 
 :005569-000030  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pear with Ginger pairing" ;
@@ -24097,10 +24139,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000040 ;
         :matchScore            "0.110236220061779"^^xsd:double .
 
-:c029a758-917d-447d-a550-b6b5676e1f71
+:fc09d9e6-fcbc-43cc-92ef-d1037741a940
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :vanilla_aroma ;
-        :sensoryValue          "0.375"^^xsd:double .
+        :hasSensoryDescriptor  :melon_aroma ;
+        :sensoryValue          "15.0"^^xsd:double .
 
 :000213-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Acacia Honey pairing" ;
@@ -24262,21 +24304,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.0160888880491257"^^xsd:double .
 
-:d053849f-89d5-4a1d-a3f3-7208499d51c8
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000157-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Dark Chocolate pairing" ;
         :hasKeyIngredient      :000157 ;
         :hasRelatedIngredient  :006821 ;
         :matchScore            "0.178074568510056"^^xsd:double .
-
-:f9d95e38-db01-405c-9a82-a03b0ba8affe
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :crunchy_texture ;
-        :sensoryValue          true .
 
 :000082-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Belgian Endive with Pumpkin pairing" ;
@@ -24302,10 +24334,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.00357142859138548"^^xsd:double .
 
-:woody_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "woody_aroma"@en ;
-        :aromaIntensity  "0.5"^^xsd:double ;
-        :hasAromaType    :woody .
+:woody_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "woody_aroma"@en ;
+        :hasAromaType   :woody .
 
 :000105-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Green Bean with Lime pairing" ;
@@ -24377,21 +24408,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q165137"^^xsd:anyURI ;
         skos:definition         "Sweet cherries are plump, red or dark purple fruits with a juicy and sweet flavor, commonly eaten fresh."@en ;
         skos:prefLabel          "Sweet Cherry"@en ;
-        :hasAroma               :a82fd946-a877-41ec-bc48-a91b6e7e06ad , :264e28cf-09b9-4a40-a10e-48918d6aa03e , :024415ab-2085-4f93-a012-951348ff8353 ;
+        :hasAroma               :d74b7649-f29b-4a04-81ea-56b0dd4ecbad , :e5f190f6-ca02-4ecf-ac2c-b4810acb405d , :61c82d88-e7e8-418a-ad13-50dac6c96809 ;
         :hasIngredientCategory  :icat:000088 ;
-        :hasTaste               :c441da0c-0811-4671-a2b4-956745958d25 , :80d7c7f3-a8d9-491d-a0e5-bc738c4dd1d0 ;
-        :hasTexture             :abd81da5-eee7-4943-bd24-a40c74e89fd9 .
+        :hasTaste               :570cfeef-c0d4-4ab1-b021-003af2f32efc , :3179d832-56e0-4434-89d5-4a896599d451 ;
+        :hasTexture             :cf8530e9-c68c-453e-9f35-b8d36a1e6c55 .
 
 :003246-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cow Mozzarella with Armagnac pairing" ;
         :hasKeyIngredient      :003246 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.277777791023254"^^xsd:double .
-
-:aaa4cbec-5980-402b-8325-9a53fb5affb8
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "5.0"^^xsd:double .
 
 :000213-005622  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Scallop Saint Jacques pairing" ;
@@ -24577,11 +24603,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:definition  "Encompasses different types of sauces used for flavoring and enhancing the taste of dishes."@en ;
         skos:prefLabel   "Sauces Category"@en .
 
-:ef9cbfee-3758-43d8-840c-5311de286357
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "0.09"^^xsd:double .
-
 :000133-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Turkey pairing" ;
         :hasKeyIngredient      :000133 ;
@@ -24594,10 +24615,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.333889812231064"^^xsd:double .
 
-:tea_aroma  rdf:type     :SensoryDescriptor ;
-        skos:prefLabel   "tea_aroma"@en ;
-        :aromaIntensity  "5.5"^^xsd:double ;
-        :hasAromaType    :herbal .
+:tea_aroma  rdf:type    :SensoryDescriptor ;
+        skos:prefLabel  "tea_aroma"@en ;
+        :hasAromaType   :herbal .
 
 :000030-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Ginger with Humulus Shoot pairing" ;
@@ -24731,10 +24751,9 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.0557620823383331"^^xsd:double .
 
-:cocoa_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "cocoa_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :roasted .
+:cocoa_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "cocoa_aroma"@en ;
+        :hasAromaType   :roasted .
 
 :005569-000920  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pear with Cucumber pairing" ;
@@ -24819,11 +24838,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000059 ;
         :hasRelatedIngredient  :000083 ;
         :matchScore            "0.200000002980232"^^xsd:double .
-
-:8c489009-02dd-48f9-b033-9bf0dbda9d48
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :rose_aroma ;
-        :sensoryValue          "2.0"^^xsd:double .
 
 :000046-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Raspberry pairing" ;
@@ -24939,11 +24953,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001218 ;
         :matchScore            "0.00423728814348578"^^xsd:double .
 
-:99855dd8-48f4-476b-ae11-95e05ecdaaf5
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "5.949999999999999"^^xsd:double .
-
 :000157-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :000157 ;
@@ -25058,6 +25067,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000072 ;
         :matchScore            "0.193548381328583"^^xsd:double .
 
+:3fb70f4e-0da3-4f7c-9859-b9e704db8cb7
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :creamy_aroma ;
+        :sensoryValue          "0.6"^^xsd:double .
+
 :005942-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Raspberry pairing" ;
         :hasKeyIngredient      :005942 ;
@@ -25112,11 +25126,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.21875"^^xsd:double .
 
-:de636813-d689-4801-ac54-9e5b99db123c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :onion_aroma ;
-        :sensoryValue          "4.8"^^xsd:double .
-
 :000213-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Baguette pairing" ;
         :hasKeyIngredient      :000213 ;
@@ -25157,6 +25166,21 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001755 ;
         :hasRelatedIngredient  :000355 ;
         :matchScore            "0.0199999995529652"^^xsd:double .
+
+:542b5f8d-7fec-41f3-baf7-a7fec9ec1427
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :chocolate_aroma ;
+        :sensoryValue          "3.0"^^xsd:double .
+
+:4af5b46b-8093-46d7-a19b-399e5426c351
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.375"^^xsd:double .
+
+:17772f42-dfd0-42dd-b3b6-f900627c83d1
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000873-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Mustard pairing" ;
@@ -25224,16 +25248,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.571428596973419"^^xsd:double .
 
+:18878256-682c-4a29-88ad-f760187b5385
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :melting_texture ;
+        :sensoryValue          true .
+
 :003290-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Cantaloupe Melon pairing" ;
         :hasKeyIngredient      :003290 ;
         :hasRelatedIngredient  :000163 ;
         :matchScore            "0.0833333358168602"^^xsd:double .
-
-:92b015e7-adf0-4fad-82d9-e67ddda2244b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :buttery_aroma ;
-        :sensoryValue          "0.6749999999999999"^^xsd:double .
 
 :000155-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Pumpkin pairing" ;
@@ -25264,11 +25288,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000801 ;
         :hasRelatedIngredient  :000030 ;
         :matchScore            "0.00254237279295921"^^xsd:double .
-
-:e3d647d0-edd6-4d0e-9bb2-a4cb772427e0
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "1.7000000000000002"^^xsd:double .
 
 :000055-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Tequila Silver pairing" ;
@@ -25419,6 +25438,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.14260870218277"^^xsd:double .
 
+:28672bd8-fb5e-4b61-a65e-5047369da334
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.375"^^xsd:double .
+
 :000515-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster Mushroom with Cow Mozzarella pairing" ;
         :hasKeyIngredient      :000515 ;
@@ -25454,6 +25478,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000475 ;
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
+
+:12ac9ead-44d4-4ded-9043-e49d1875499d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "1.7000000000000002"^^xsd:double .
 
 :icat:000113  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000023 ;
@@ -25526,6 +25555,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.0625"^^xsd:double .
 
+:0b985d76-75d3-4c0e-8118-bc0b223ea4c8
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :grass_aroma ;
+        :sensoryValue          "0.7000000000000001"^^xsd:double .
+
 :000161-000355  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with Sweet Corn pairing" ;
         :hasKeyIngredient      :000161 ;
@@ -25563,9 +25597,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0222222227603197"^^xsd:double .
 
 :mustard_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "mustard_aroma"@en ;
-        :aromaIntensity  "10.5"^^xsd:double ;
-        :hasAromaType    :spicy .
+        skos:prefLabel  "mustard_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :005842-001218  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Cod pairing" ;
@@ -25637,11 +25670,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005754 ;
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.0223880596458912"^^xsd:double .
-
-:8c3b3737-05af-4ba0-8984-56ad1aaeb0e8
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "0.3"^^xsd:double .
 
 :000144-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Acacia Honey pairing" ;
@@ -25762,11 +25790,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000159 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.0198019798845053"^^xsd:double .
-
-:16059bc8-704f-4d31-ba02-377f8dbc5f98
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pungent_aroma ;
-        :sensoryValue          "2.1"^^xsd:double .
 
 :001755-001959  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Grappa pairing" ;
@@ -25951,7 +25974,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q60855"^^xsd:anyURI ;
         skos:definition         "Fragrant tea made by infusing green tea leaves with jasmine flowers, known for its floral aroma."@en ;
         skos:prefLabel          "Jasmine Tea"@en ;
-        :hasAroma               :b2eb5cdd-9926-4aac-86fd-08e73e541752 , :c54959c6-bf97-4660-811e-1d2eb4339cbe , :0db3c3a5-7150-4d1a-be4c-da25b6400bf9 ;
+        :hasAroma               :222456c5-743d-4b20-bcba-ad19005f591f , :0aec95f0-4799-41e1-a76a-c529b9ef57ae , :1e625fea-51ef-4dd3-ac46-7e8c857806c6 ;
         :hasIngredientCategory  :icat:000079 .
 
 :000163-003290  rdf:type       :IngredientPairing ;
@@ -25959,11 +25982,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000163 ;
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.158730164170265"^^xsd:double .
-
-:12368e47-6471-48de-9494-fd21139df20e
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pear_aroma ;
-        :sensoryValue          "10.5"^^xsd:double .
 
 :000887-000252  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Sweet Potato pairing" ;
@@ -26022,11 +26040,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000151 ;
         :matchScore            "0.0222222227603197"^^xsd:double .
 
-:b8b32248-c148-4cd0-aa9c-65685a9672ad
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :chocolate_aroma ;
-        :sensoryValue          "9.0"^^xsd:double .
-
 :000117-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Lemon pairing" ;
         :hasKeyIngredient      :000117 ;
@@ -26074,10 +26087,14 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.0195771344006062"^^xsd:double .
 
+:f7f61704-f10e-4de1-8937-ff444f3de966
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :honey_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :asparagus_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "asparagus_aroma"@en ;
-        :aromaIntensity  "7.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "asparagus_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :001394-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Chorizo pairing" ;
@@ -26090,6 +26107,11 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000046 ;
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.207606971263885"^^xsd:double .
+
+:935cd08c-40ed-4cfd-a8a1-4c1354ac2d75
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :crunchy_texture ;
+        :sensoryValue          true .
 
 :000413-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Apple 'Jonagold' with Green Bean pairing" ;
@@ -26145,10 +26167,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006473 ;
         :matchScore            "0.0476190485060215"^^xsd:double .
 
-:562a71a1-9075-4cf6-a3d8-bfcc28279a9e
+:61c82d88-e7e8-418a-ad13-50dac6c96809
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :acidic_aroma ;
-        :sensoryValue          "0.7000000000000001"^^xsd:double .
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "2.25"^^xsd:double .
 
 :000141-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Red Bell Pepper pairing" ;
@@ -26161,11 +26183,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000520 ;
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.292307704687119"^^xsd:double .
-
-:29c810f4-12c2-45f9-800f-9bd74f57f057
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "0.45"^^xsd:double .
 
 :000021-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Chorizo pairing" ;
@@ -26203,11 +26220,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.225806444883347"^^xsd:double .
 
-:ef6a4089-bcac-4b4f-8be1-668cd55a7b9e
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "4.0"^^xsd:double .
-
 :000887-000215  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Beetroot pairing" ;
         :hasKeyIngredient      :000887 ;
@@ -26231,11 +26243,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000030 ;
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.138906747102737"^^xsd:double .
-
-:f20502d9-15b0-45f5-bc4c-d6e41c1f094b
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "2.0"^^xsd:double .
 
 :000791-000787  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Vanilla 'Bourbon' pairing" ;
@@ -26308,11 +26315,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         skos:definition  "Encompasses a type of cheese characterized by the presence of blue or green veins of mold, known for its distinct flavor."@en ;
         skos:prefLabel   "Blue Cheese"@en .
 
-:45b06c8b-9101-4768-a1af-8126e757bb9b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "0.625"^^xsd:double .
-
 :000040-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Grape pairing" ;
         :hasKeyIngredient      :000040 ;
@@ -26324,11 +26326,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000142 ;
         :hasRelatedIngredient  :000920 ;
         :matchScore            "0.0483870953321457"^^xsd:double .
-
-:3fb8597f-bdc4-4f19-af51-14d389d3f47c
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :salt_taste ;
-        :sensoryValue          "0.2"^^xsd:double .
 
 :000801-000865  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Sake pairing" ;
@@ -26347,11 +26344,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000017 ;
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.0754242613911629"^^xsd:double .
-
-:31f385ae-ed61-4ff6-afcc-4d6e1a3987d0
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :camphor_aroma ;
-        :sensoryValue          "14.0"^^xsd:double .
 
 :000281-000215  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Beetroot pairing" ;
@@ -26437,10 +26429,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006002 ;
         :matchScore            "0.00939849577844143"^^xsd:double .
 
-:53d9f411-80f3-4cf0-b29b-e1d58f095d84
+:75ec6f4f-dba2-429f-b17e-11005652a6e2
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :rose_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
+        :hasSensoryDescriptor  :milk_aroma ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :000313-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Brewed Coffee pairing" ;
@@ -26453,11 +26445,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000013 ;
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.0580046400427818"^^xsd:double .
-
-:02dd4f80-a76e-4e7f-adfb-ee32427665c1
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :beany_aroma ;
-        :sensoryValue          "1.5"^^xsd:double .
 
 :001755-005842  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Garlic Puree pairing" ;
@@ -26524,7 +26511,7 @@ dct:license  rdf:type  owl:AnnotationProperty .
         rdfs:range       [ rdf:type     rdfs:Datatype ;
                            owl:unionOf  ( xsd:boolean xsd:double )
                          ] ;
-        skos:definition  "Represents the 'raw' sensory value for certain descriptors."@en ;
+        skos:definition  "Represents the sensory value for certain descriptors."@en ;
         skos:prefLabel   "sensory value"@en .
 
 :000055-000159  rdf:type       :IngredientPairing ;
@@ -26623,10 +26610,10 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.0129870129749179"^^xsd:double .
 
-:a7ddd041-10a1-4e21-bc3f-16a3d29dd156
+:132729e4-b118-4183-b362-4574d2584007
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.375"^^xsd:double .
+        :hasSensoryDescriptor  :milk_aroma ;
+        :sensoryValue          "2.0"^^xsd:double .
 
 :000142-000123  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Rosemary pairing" ;
@@ -26700,16 +26687,16 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000030 ;
         :matchScore            "0.0175438597798347"^^xsd:double .
 
-:b5eacf6b-d9f4-445f-8859-ae51d139d39a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "1.25"^^xsd:double .
-
 :000021-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Grape pairing" ;
         :hasKeyIngredient      :000021 ;
         :hasRelatedIngredient  :001696 ;
         :matchScore            "0.176470592617989"^^xsd:double .
+
+:49a5e334-6484-46a9-95d9-8840aec15f28
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :camphor_aroma ;
+        :sensoryValue          "7.0"^^xsd:double .
 
 :000142-001959  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Grappa pairing" ;
@@ -26722,11 +26709,6 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000135 ;
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.713012456893921"^^xsd:double .
-
-:f95555a6-20c6-48f8-a10f-1567f99adab3
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :acidic_aroma ;
-        :sensoryValue          "0.17500000000000002"^^xsd:double .
 
 :000017-001624  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tomato with Vodka pairing" ;
@@ -26801,9 +26783,8 @@ dct:license  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0827586203813553"^^xsd:double .
 
 :garlic_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "garlic_aroma"@en ;
-        :aromaIntensity  "16.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "garlic_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :007088-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Armagnac with Basil Leaf pairing" ;
@@ -26847,9 +26828,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q14088"^^xsd:anyURI ;
         skos:definition         "Soft, mild cheese made from cow's milk, commonly used in salads and pizzas."@en ;
         skos:prefLabel          "Cow Mozzarella"@en ;
-        :hasAroma               :aca56bf0-0dee-4f8b-8895-154ed7f36417 ;
+        :hasAroma               :4d96f0f0-26ca-4c8a-b4d9-b9fbd41f5003 ;
         :hasIngredientCategory  :icat:000054 ;
-        :hasTexture             :6694a3fe-3b19-4da4-b8a4-99dd5faec7c0 .
+        :hasTexture             :70df6f35-2b77-4756-b5d6-f0bcf4baefaa .
 
 :000072-000091  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemon with Chervil pairing" ;
@@ -26977,6 +26958,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000123 ;
         :matchScore            "0.600000023841858"^^xsd:double .
 
+:e5f190f6-ca02-4ecf-ac2c-b4810acb405d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :berry_aroma ;
+        :sensoryValue          "19.0"^^xsd:double .
+
 :000215-005754  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Hamburger pairing" ;
         :hasKeyIngredient      :000215 ;
@@ -27096,9 +27082,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.133333340287209"^^xsd:double .
 
 :juniper_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "juniper_aroma"@en ;
-        :aromaIntensity  "0.5"^^xsd:double ;
-        :hasAromaType    :spicy .
+        skos:prefLabel  "juniper_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :000181-000014  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Boiled Egg pairing" ;
@@ -27147,6 +27132,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001218 ;
         :hasRelatedIngredient  :000876 ;
         :matchScore            "0.0285714287310839"^^xsd:double .
+
+:c27498ed-2038-4ab9-a0b3-4a9dd75c8d72
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cabbage_aroma ;
+        :sensoryValue          "2.85"^^xsd:double .
 
 :000135-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Raspberry with Champignon Mushroom pairing" ;
@@ -27202,11 +27192,21 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.476190477609634"^^xsd:double .
 
+:7b003183-f584-448f-bb5d-6562693f7e8f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :orange_aroma ;
+        :sensoryValue          "0.25"^^xsd:double .
+
 :000059-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Baguette pairing" ;
         :hasKeyIngredient      :000059 ;
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.0799999982118607"^^xsd:double .
+
+:5707687a-98bc-4f7d-b8c5-a8513636ccba
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :creamy_aroma ;
+        :sensoryValue          "0.6"^^xsd:double .
 
 :000055-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Pea pairing" ;
@@ -27255,6 +27255,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005675 ;
         :hasRelatedIngredient  :000161 ;
         :matchScore            "0.0148031497374177"^^xsd:double .
+
+:ee224f9f-0d7d-4fd8-89e5-514619d4819f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :milk_aroma ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :000110-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Leek with Orange pairing" ;
@@ -27382,6 +27387,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :007105 ;
         :matchScore            "0.00192926044110209"^^xsd:double .
 
+:e328bb57-18b8-4ec2-b19b-e0454e4bf65c
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :umami_taste ;
+        :sensoryValue          "0.3"^^xsd:double .
+
 :000791-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Oyster pairing" ;
         :hasKeyIngredient      :000791 ;
@@ -27453,6 +27463,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000142 ;
         :hasRelatedIngredient  :005842 ;
         :matchScore            "0.0483870953321457"^^xsd:double .
+
+:f1073d4e-da3d-4939-8b1e-b6d1df90d5b1
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "4.0"^^xsd:double .
 
 :000452-000215  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Beetroot pairing" ;
@@ -27566,9 +27581,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q37937"^^xsd:anyURI ;
         skos:definition         "Sweet potatoes are starchy, orange-fleshed tubers with a naturally sweet taste, commonly baked, mashed, or used in various culinary preparations."@en ;
         skos:prefLabel          "Sweet Potato"@en ;
-        :hasAroma               :64704272-8f20-45de-92f6-ef3f2d11a7b6 , :16075913-b852-44aa-997f-27eddea7f687 , :2d71ffd4-03a8-4e56-9906-4fe1dafdad50 , :79419599-237c-4621-ab06-744f88a13139 ;
+        :hasAroma               :ea03b9ec-a277-4d35-a94d-e902fab8e06e , :7e3c3199-1afa-4743-8517-26b9729ac60d , :9d932e97-1f6f-4823-b4a4-35080329f7f1 , :56d297e8-ff18-4486-8d0a-5d5a3dfc0025 ;
         :hasIngredientCategory  :icat:000137 ;
-        :hasTexture             :51d6e089-6b24-48b0-a57b-741261932aa9 .
+        :hasTexture             :810b3dcb-2b1b-46b5-bc99-e0bbe2edccfb .
 
 :005842-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Orange pairing" ;
@@ -27624,10 +27639,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0763157904148102"^^xsd:double .
 
-:32e03a99-5ca6-4917-bd8b-d97fa0daa455
+:089f561d-3a7e-4335-bdeb-3e304186b3bc
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :meaty_aroma ;
-        :sensoryValue          "0.63"^^xsd:double .
+        :hasSensoryDescriptor  :garlic_aroma ;
+        :sensoryValue          "48.0"^^xsd:double .
 
 :000281-001624  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Vodka pairing" ;
@@ -27646,11 +27661,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005754 ;
         :hasRelatedIngredient  :000161 ;
         :matchScore            "0.108059704303741"^^xsd:double .
-
-:e39ee8e3-3c10-41b6-a434-14af94bfd122
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cucumber_aroma ;
-        :sensoryValue          "33.0"^^xsd:double .
 
 :000040-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Dark Chocolate pairing" ;
@@ -27686,6 +27696,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000017 ;
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.41609051823616"^^xsd:double .
+
+:c34497d5-0609-4196-9152-9128e5dd4f6f
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :hard_texture ;
+        :sensoryValue          true .
 
 :000873-000031  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Lemongrass pairing" ;
@@ -27807,11 +27822,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000123 ;
         :matchScore            "0.16666667163372"^^xsd:double .
 
-:0436810f-923a-4dab-aeae-f1e4fe060f3b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :smoky_aroma ;
-        :sensoryValue          "1.5"^^xsd:double .
-
 :000014-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Boiled Egg with Mayonnaise pairing" ;
         :hasKeyIngredient      :000014 ;
@@ -27895,6 +27905,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000046 ;
         :hasRelatedIngredient  :007170 ;
         :matchScore            "0.0297939777374268"^^xsd:double .
+
+:619295fd-bae2-4866-997f-446e511c5b56
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :corn_aroma ;
+        :sensoryValue          "13.5"^^xsd:double .
 
 :006821-001218  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Cod pairing" ;
@@ -28014,11 +28029,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.404017865657806"^^xsd:double .
 
-:1f2d6423-62f6-4ae2-8c8e-fdaa497a8ba2
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pineapple_aroma ;
-        :sensoryValue          "2.25"^^xsd:double .
-
 :003290-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Pea pairing" ;
         :hasKeyIngredient      :003290 ;
@@ -28030,6 +28040,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000787 ;
         :hasRelatedIngredient  :000107 ;
         :matchScore            "0.0038167939055711"^^xsd:double .
+
+:8a95a5b7-e031-4945-b94b-0c8809779328
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "0.9"^^xsd:double .
 
 :000141-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Sweet Vermouth pairing" ;
@@ -28132,10 +28147,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000144 ;
         :matchScore            "0.192691028118134"^^xsd:double .
 
-:4207f25d-7f20-4f05-a561-1c602601641e
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
+:299c82ae-856f-4a7e-b5ef-b11d4638a8da
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :onion_aroma ;
+        :sensoryValue          "4.8"^^xsd:double .
 
 :000136-005842  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Garlic Puree pairing" ;
@@ -28215,11 +28230,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000886 ;
         :matchScore            "0.0365448519587517"^^xsd:double .
 
-:a3829290-4c9d-4289-94ae-2d01ce8b173a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cabbage_aroma ;
-        :sensoryValue          "2.85"^^xsd:double .
-
 :000091-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chervil with Yellow Nectarine pairing" ;
         :hasKeyIngredient      :000091 ;
@@ -28236,11 +28246,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         skos:broader     :icat:000012 ;
         skos:definition  "Refers to substances used to add or enhance color in food and beverages, such as natural or synthetic food dyes."@en ;
         skos:prefLabel   "Colouring"@en .
-
-:c5478fd9-f6d7-4d29-bde8-a5f491b6b7c2
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "3.8"^^xsd:double .
 
 :000311-000213  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Red Cabbage pairing" ;
@@ -28359,6 +28364,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
 
+:0824b9a7-82f0-482e-887c-b7fe69c20603
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "4.25"^^xsd:double .
+
 :007105-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Gruyère pairing" ;
         :hasKeyIngredient      :007105 ;
@@ -28413,6 +28423,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.186666667461395"^^xsd:double .
 
+:3502e2b8-ae76-4f21-a9ad-4f806ce4d910
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :camphor_aroma ;
+        :sensoryValue          "14.0"^^xsd:double .
+
 :000149-005842  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Garlic Puree pairing" ;
         :hasKeyIngredient      :000149 ;
@@ -28466,21 +28481,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.270096451044083"^^xsd:double .
 
-:c54959c6-bf97-4660-811e-1d2eb4339cbe
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :jasmin_aroma ;
-        :sensoryValue          "19.5"^^xsd:double .
-
 :001755-000096  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Chives pairing" ;
         :hasKeyIngredient      :001755 ;
         :hasRelatedIngredient  :000096 ;
         :matchScore            "0.100000001490116"^^xsd:double .
-
-:b0c72508-ba0b-4b09-aab2-99f1102c562e
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "2.2"^^xsd:double .
 
 :floral  rdf:type       :AromaType ;
         skos:prefLabel  "floral"@en .
@@ -28496,11 +28501,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000133 ;
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.29372826218605"^^xsd:double .
-
-:008f3d33-6bfb-49df-a51a-3f76f5ef04d4
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
 
 :000252-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Potato with Mustard pairing" ;
@@ -28560,11 +28560,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13195"^^xsd:anyURI ;
         skos:definition         "Limes are small, green citrus fruits with a tart and tangy flavor, commonly used in cooking and beverages."@en ;
         skos:prefLabel          "Lime"@en ;
-        :hasAroma               :584a3b40-5e70-4867-827d-e886f6cd3821 , :1e1410a8-0888-472a-b68c-5d9362879d5e , :2f24ecac-a557-4ed1-aa67-cb46db928fc0 , :4bf77b47-b348-4841-bfb7-b80073442562 ;
+        :hasAroma               :1dbe9cb3-d6cb-4c1b-bf1c-8b82a0bbd568 , :c7738211-2afe-46db-a768-300ee3a670c1 , :8dedf1d7-f4dd-4488-b13c-62ec498f82d3 , :4add3515-a63d-4754-9367-5ca96f4af659 ;
         :hasFunctionalBenefit   :Weight-loss , :Weight-gain , :Prebiotic , :Antioxidant , :Energy , :Brain , :Digestion , :Minerals , :Bone , :Immunity ;
         :hasIngredientCategory  :icat:000089 ;
-        :hasTaste               :361e400e-b58c-4d1d-8616-fdbaa05b6ecb ;
-        :hasTexture             :bac6bd4d-9418-4376-bb87-2b4f50765aae .
+        :hasTaste               :91dc6c02-436c-4d26-829e-55283498c3ef ;
+        :hasTexture             :46ec56d7-e8d0-4db9-8945-d52695cabeb3 .
 
 :005942-006002  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Pasta pairing" ;
@@ -28630,6 +28630,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000107 ;
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.146828502416611"^^xsd:double .
+
+:dad71ed9-17c3-4790-92cd-a8e6c564a9fb
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :ethanol_aroma ;
+        :sensoryValue          "22.0"^^xsd:double .
 
 :001394-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Champignon Mushroom pairing" ;
@@ -28730,11 +28735,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005842 ;
         :hasRelatedIngredient  :000472 ;
         :matchScore            "0.122676581144333"^^xsd:double .
-
-:5bd3d122-e453-4ba8-b6da-83c0733a87ce
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
 
 :000306-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Green Bean pairing" ;
@@ -28855,6 +28855,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001696 ;
         :matchScore            "0.253333330154419"^^xsd:double .
 
+:2df57f66-4471-4b02-a8bd-8149ce7b3418
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
+
 :005930-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Emmentaler pairing" ;
         :hasKeyIngredient      :005930 ;
@@ -28867,15 +28872,14 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000920 ;
         :matchScore            "0.0969857424497604"^^xsd:double .
 
-:361e400e-b58c-4d1d-8616-fdbaa05b6ecb
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "5.0"^^xsd:double .
+:nutty_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "nutty_aroma"@en ;
+        :hasAromaType   :nutty .
 
-:nutty_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "nutty_aroma"@en ;
-        :aromaIntensity  "0.75"^^xsd:double ;
-        :hasAromaType    :nutty .
+:ba17526f-042b-410b-a36b-7c84a3a5a199
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cucumber_aroma ;
+        :sensoryValue          "6.6"^^xsd:double .
 
 :000151-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pineapple with Yellow Nectarine pairing" ;
@@ -28887,7 +28891,7 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q374"^^xsd:anyURI ;
         skos:definition         "Colorless and flavorless distilled spirit made from fermented grains or potatoes, commonly used in cocktails."@en ;
         skos:prefLabel          "Vodka"@en ;
-        :hasAroma               :d7006e22-cbc4-4a1d-bf96-4ddd67f7895b , :ea0e9f63-b7cf-49d7-8f3b-2bf110a93ede , :98e85c53-d95a-4961-bd90-1df60af91f47 , :5b71e5b2-d983-401d-91a8-92791d0af43a ;
+        :hasAroma               :6e3ef384-08e0-486b-89f9-3d22b3b11c00 , :18c0d518-4677-403a-868f-5111e32da9de , :9aba9679-2a7c-47db-ab34-35b65e462972 , :dad71ed9-17c3-4790-92cd-a8e6c564a9fb ;
         :hasFunctionalBenefit   :Diabetic , :Sleep , :Stress , :Energy ;
         :hasIngredientCategory  :icat:000072 .
 
@@ -28936,10 +28940,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000096 ;
         :matchScore            "0.152542367577553"^^xsd:double .
 
-:rice_aroma  rdf:type    :SensoryDescriptor ;
-        skos:prefLabel   "rice_aroma"@en ;
-        :aromaIntensity  "1.75"^^xsd:double ;
-        :hasAromaType    :green .
+:rice_aroma  rdf:type   :SensoryDescriptor ;
+        skos:prefLabel  "rice_aroma"@en ;
+        :hasAromaType   :green .
 
 :005842-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Chorizo pairing" ;
@@ -28966,9 +28969,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0299999993294477"^^xsd:double .
 
 :celery_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "celery_aroma"@en ;
-        :aromaIntensity  "11.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "celery_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000452-000475  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Pecan Nut pairing" ;
@@ -29010,16 +29012,16 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.0444444455206394"^^xsd:double .
 
-:7c298028-faf1-4bcc-a27c-afedeecbf9da
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "5.0"^^xsd:double .
-
 :000046-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Yellow Grapefruit pairing" ;
         :hasKeyIngredient      :000046 ;
         :hasRelatedIngredient  :000159 ;
         :matchScore            "0.0792393013834953"^^xsd:double .
+
+:20b86595-8d65-4828-89a0-850db345505d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "0.625"^^xsd:double .
 
 :006473-000014  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster with Boiled Egg pairing" ;
@@ -29159,11 +29161,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.125"^^xsd:double .
 
-:3c1024ba-4d1f-4854-af24-ddf19735ce3b
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :creamy_texture ;
-        :sensoryValue          true .
-
 :000306-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Atlantic Salmon with Veal pairing" ;
         :hasKeyIngredient      :000306 ;
@@ -29228,10 +29225,15 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q1119911"^^xsd:anyURI ;
         skos:definition         "Buttery, oval-shaped nuts with a rich and nutty flavor, commonly used in baking and desserts."@en ;
         skos:prefLabel          "Pecan Nut"@en ;
-        :hasAroma               :3449ae5e-3d64-4cac-9f0e-e2160830231b , :c6bad883-2d29-4f2b-a266-68f8197cfd30 , :b96a62cb-05b8-45fa-b841-8bbe63555bd8 , :bcda0e07-34ed-40af-92eb-17267798fa0c , :ca6b187b-58a7-4c5a-8fb3-b3d3e9e2c420 ;
+        :hasAroma               :d64c03af-ce32-4755-b738-1a5a8c22f9a0 , :94429cec-390c-4037-a727-8a763c8864b5 , :c7cb9ead-ddde-4044-9a0a-cebe4b0c60bb , :269f9416-11bb-40e4-be7a-ee60b5c32924 , :a63ebb08-71f6-4553-abda-37b50309aa58 ;
         :hasFunctionalBenefit   :Antioxidant ;
         :hasIngredientCategory  :icat:000100 ;
-        :hasTexture             :84504718-20d7-4317-bc45-fa2967711558 .
+        :hasTexture             :b86cf805-4d6d-479f-92f5-ceff6fa8bf9e .
+
+:74e84ce3-af64-4ed9-b043-8cc684248fe6
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.07500000000000001"^^xsd:double .
 
 :000142-000096  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Chives pairing" ;
@@ -29286,6 +29288,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000801 ;
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.127118647098541"^^xsd:double .
+
+:57e8edd1-094f-4fef-8ba2-b240eef91d45
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.25"^^xsd:double .
 
 :001696-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grape with Armagnac pairing" ;
@@ -29361,11 +29368,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000993 ;
         :hasRelatedIngredient  :000472 ;
         :matchScore            "0.0751879662275314"^^xsd:double .
-
-:cc2f5ae7-2c4e-4142-a667-81fd86a86961
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
 
 :sweet_taste  rdf:type  :SensoryDescriptor ;
         skos:prefLabel  "sweet_taste"@en .
@@ -29457,6 +29459,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007170 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.308910876512527"^^xsd:double .
+
+:36a991b2-c65f-4626-b64c-eab2a0012f2b
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :crunchy_texture ;
+        :sensoryValue          true .
 
 :000355-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Raspberry pairing" ;
@@ -29620,11 +29627,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005760 ;
         :matchScore            "0.138839289546013"^^xsd:double .
 
-:f54709ba-d50b-4d7d-b34e-cf439231b1f2
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fermented_aroma ;
-        :sensoryValue          "1.1"^^xsd:double .
-
 :001394-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Acacia Honey pairing" ;
         :hasKeyIngredient      :001394 ;
@@ -29685,20 +29687,15 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.0928074270486832"^^xsd:double .
 
-:92b2ebdb-3d9f-47fd-8c6c-7490b5faf81d
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :melting_texture ;
-        :sensoryValue          true .
-
 :000090  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q217525"^^xsd:anyURI ;
         skos:definition         "A type of cheese known for its sharp and tangy flavor, commonly used in cooking and as a topping."@en ;
         skos:prefLabel          "Cheddar"@en ;
-        :hasAroma               :76ec1b18-490d-4031-a039-19fec398197e , :a540e182-ac6c-41b7-abc1-e241907960d4 , :fcbefd61-0e20-4036-b54d-af26cea2be52 ;
+        :hasAroma               :45da55a6-074f-4de6-9a74-e96f8defc324 , :6f0021e8-5983-4b7a-b3ed-256bab0f6d0c , :f3cea537-ac68-4f20-a1b2-c0451832d861 ;
         :hasFunctionalBenefit   :Digestion , :Antioxidant , :Probiotic , :Brain ;
         :hasIngredientCategory  :icat:000055 ;
-        :hasTaste               :96c93d23-a868-4e70-b48a-e7c6f14fc463 , :3fb8597f-bdc4-4f19-af51-14d389d3f47c ;
-        :hasTexture             :1e27501c-f2f6-427d-a98e-4a608201b4e8 , :a1b74fe7-93f6-4d8c-afe5-dd84ea890303 .
+        :hasTaste               :511f32e1-7f08-4099-b689-268c3ce6e0d5 , :e6493be6-c86c-4a3c-9990-aea338c5aad3 ;
+        :hasTexture             :96513123-f930-4594-adce-55b096e3a9ca , :70185ac9-b52f-48de-81a7-c6680ce2afc6 .
 
 :hasAromaType  rdf:type  owl:ObjectProperty ;
         rdfs:domain      :SensoryDescriptor ;
@@ -29724,6 +29721,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000887 ;
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.15384615957737"^^xsd:double .
+
+:cf18e7c1-93c0-45e1-bd96-d105f310c505
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :earthy_aroma ;
+        :sensoryValue          "0.9500000000000001"^^xsd:double .
 
 :000840-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "London Dry Gin with Armagnac pairing" ;
@@ -29791,6 +29793,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000252 ;
         :matchScore            "0.181818187236786"^^xsd:double .
 
+:586ded93-8f43-410e-98c7-8ab719a6c760
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :meaty_aroma ;
+        :sensoryValue          "0.63"^^xsd:double .
+
 :000040-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Sweet Vermouth pairing" ;
         :hasKeyIngredient      :000040 ;
@@ -29820,10 +29827,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000144 ;
         :matchScore            "0.0181818176060915"^^xsd:double .
 
-:c25415b5-f09d-4e51-92c8-819cd0670b82
+:92ae0c09-6cb3-4192-b1ff-0eb5b4426fa7
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :onion_aroma ;
-        :sensoryValue          "8.0"^^xsd:double .
+        :hasSensoryDescriptor  :acidic_aroma ;
+        :sensoryValue          "0.17500000000000002"^^xsd:double .
 
 :000133-005842  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Garlic Puree pairing" ;
@@ -29873,11 +29880,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.0251256283372641"^^xsd:double .
 
-:a15354bd-c85e-43d9-a386-12b00fd8d762
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :melon_aroma ;
-        :sensoryValue          "15.0"^^xsd:double .
-
 :000281-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Basil Leaf pairing" ;
         :hasKeyIngredient      :000281 ;
@@ -29891,9 +29893,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.147058829665184"^^xsd:double .
 
 :chocolate_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "chocolate_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :roasted .
+        skos:prefLabel  "chocolate_aroma"@en ;
+        :hasAromaType   :roasted .
 
 :000155-001755  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Cava pairing" ;
@@ -30045,6 +30046,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.0625"^^xsd:double .
 
+:bc82ce1f-6421-46f8-a6a8-845ad3d7f196
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.25"^^xsd:double .
+
 :003143-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Spinach pairing" ;
         :hasKeyIngredient      :003143 ;
@@ -30056,6 +30062,21 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000801 ;
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.169491529464722"^^xsd:double .
+
+:bdf71b20-c2b3-4ea6-9f91-56ac5a5ce6aa
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
+
+:2cbe3d44-ab1f-40d9-a6cf-296b97542719
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
+:1bf685a4-5114-4929-bc6b-beebe8cd8fac
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "5.0"^^xsd:double .
 
 :000040-003290  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Brie pairing" ;
@@ -30105,6 +30126,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :007105 ;
         :matchScore            "0.0476190485060215"^^xsd:double .
 
+:5849dad0-a53a-4f50-9142-128afb71719f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :potato_aroma ;
+        :sensoryValue          "0.24"^^xsd:double .
+
 :001394-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Sweet Vermouth pairing" ;
         :hasKeyIngredient      :001394 ;
@@ -30116,6 +30142,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000123 ;
         :hasRelatedIngredient  :000091 ;
         :matchScore            "0.294117659330368"^^xsd:double .
+
+:6f0021e8-5983-4b7a-b3ed-256bab0f6d0c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000520-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brussels Sprouts with Orange pairing" ;
@@ -30410,11 +30441,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.0657894760370255"^^xsd:double .
 
-:ab667da2-27ad-48bf-803d-2b4632dbdd98
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :spicy_aroma ;
-        :sensoryValue          "0.22499999999999998"^^xsd:double .
-
 :001008-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk Chocolate with Lemon pairing" ;
         :hasKeyIngredient      :001008 ;
@@ -30494,9 +30520,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0866141766309738"^^xsd:double .
 
 :animal_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "animal_aroma"@en ;
-        :aromaIntensity  "10.5"^^xsd:double ;
-        :hasAromaType    :animal .
+        skos:prefLabel  "animal_aroma"@en ;
+        :hasAromaType   :animal .
 
 :000155-000017  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Tomato pairing" ;
@@ -30515,11 +30540,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007105 ;
         :hasRelatedIngredient  :000515 ;
         :matchScore            "0.199335545301437"^^xsd:double .
-
-:58cf35fd-33f3-4b98-8df8-a94188e37b6e
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "5.0"^^xsd:double .
 
 :000865-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sake with Cheddar pairing" ;
@@ -30568,6 +30588,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005483 ;
         :hasRelatedIngredient  :006473 ;
         :matchScore            "0.103896103799343"^^xsd:double .
+
+:9985c9a2-863d-42ba-af8e-1c1b5db9bc6b
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.15000000000000002"^^xsd:double .
 
 :005545-000149  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mussel with Banana pairing" ;
@@ -30673,6 +30698,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         skos:broader     :icat:000061 ;
         skos:definition  "Refers to a beverage made by steeping ingredients like herbs, fruits, or flowers in hot water, creating flavored and aromatic drinks."@en ;
         skos:prefLabel   "Infusion"@en .
+
+:03e01765-899e-4f03-be45-903c8f06920d
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :melting_texture ;
+        :sensoryValue          true .
 
 :000082-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Belgian Endive with Yellow Nectarine pairing" ;
@@ -30872,6 +30902,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000059 ;
         :matchScore            "0.322580635547638"^^xsd:double .
 
+:f3cea537-ac68-4f20-a1b2-c0451832d861
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :buttery_aroma ;
+        :sensoryValue          "0.6749999999999999"^^xsd:double .
+
 :000313-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Lime pairing" ;
         :hasKeyIngredient      :000313 ;
@@ -30925,11 +30960,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000105 ;
         :hasRelatedIngredient  :008970 ;
         :matchScore            "0.317632853984833"^^xsd:double .
-
-:d8fa9174-05ce-4026-b0e5-5b769d33fe5d
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :creamy_texture ;
-        :sensoryValue          true .
 
 :000452-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pumpkin with Basil Leaf pairing" ;
@@ -30985,6 +31015,16 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001008 ;
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.0819672122597694"^^xsd:double .
+
+:b0d82819-d25c-498f-9ce9-1b3738d0e310
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :creamy_texture ;
+        :sensoryValue          true .
+
+:757ec09a-7430-436b-b92f-9d063bfdd8bf
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
 
 :000105-005569  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Green Bean with Pear pairing" ;
@@ -31076,6 +31116,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000281 ;
         :matchScore            "0.510638296604156"^^xsd:double .
 
+:18c0d518-4677-403a-868f-5111e32da9de
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :buttery_aroma ;
+        :sensoryValue          "0.0225"^^xsd:double .
+
 :003143-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Humulus Shoot pairing" ;
         :hasKeyIngredient      :003143 ;
@@ -31128,11 +31173,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005760 ;
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.142857149243355"^^xsd:double .
-
-:36864fb2-3cd3-45ef-83ae-02806bd43920
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fishy_aroma ;
-        :sensoryValue          "4.0"^^xsd:double .
 
 :000047-003290  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic with Brie pairing" ;
@@ -31242,16 +31282,20 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000017 ;
         :matchScore            "0.012269938364625"^^xsd:double .
 
+:cee7ad0a-9016-4ef0-9a5d-0ae6e8f9a832
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :umami_taste ;
+        :sensoryValue          "0.3"^^xsd:double .
+
 :005842-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Red Bell Pepper pairing" ;
         :hasKeyIngredient      :005842 ;
         :hasRelatedIngredient  :000083 ;
         :matchScore            "0.0371747203171253"^^xsd:double .
 
-:thyme_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "thyme_aroma"@en ;
-        :aromaIntensity  "8.0"^^xsd:double ;
-        :hasAromaType    :herbal .
+:thyme_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "thyme_aroma"@en ;
+        :hasAromaType   :herbal .
 
 :000520-000110  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brussels Sprouts with Leek pairing" ;
@@ -31288,11 +31332,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007088 ;
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.0244897957891226"^^xsd:double .
-
-:6dc34eab-e17e-48ee-951c-12211962adf5
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :hard_texture ;
-        :sensoryValue          true .
 
 :005483-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Avocado pairing" ;
@@ -31334,7 +31373,7 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q65522654"^^xsd:anyURI ;
         skos:definition         "A basil leaf is a fragrant, green leaf with a strong, sweet aroma, often used as a herb in cooking."@en ;
         skos:prefLabel          "Basil Leaf"@en ;
-        :hasAroma               :ba5143f1-886b-4243-8cb4-fd8337bde38a , :8318cdf0-9fff-4670-828f-ecf558616562 , :f8d43e2a-9640-48db-8e5a-54505bd0e4f4 , :64bfaed5-82b7-4de9-a641-540b1f9b1e46 ;
+        :hasAroma               :c5e3ebb2-2e10-4127-a23d-65858c18fec5 , :e3f50eab-a3d9-4368-a6a0-c387d012e1d5 , :1e551577-54ab-42da-a1ce-cb887934db7c , :57e8edd1-094f-4fef-8ba2-b240eef91d45 ;
         :hasFunctionalBenefit   :Antibacterial , :Brain , :Antioxidant , :Digestion , :Diabetic , :Stress , :Probiotic , :Energy , :Immunity , :Minerals , :Cardiovascular ;
         :hasIngredientCategory  :icat:000094 .
 
@@ -31372,11 +31411,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000159 ;
         :hasRelatedIngredient  :003246 ;
         :matchScore            "0.0990099012851715"^^xsd:double .
-
-:c40cc390-9616-4dec-a0db-efb981592748
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :animal_aroma ;
-        :sensoryValue          "0.105"^^xsd:double .
 
 :000133-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Milk pairing" ;
@@ -31420,21 +31454,21 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.425535708665848"^^xsd:double .
 
-:502ea1f9-88d5-4d31-8a5b-fbdf6fa7e8bb
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :egg_aroma ;
-        :sensoryValue          "6.0"^^xsd:double .
-
 :005483-001394  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Popcorn pairing" ;
         :hasKeyIngredient      :005483 ;
         :hasRelatedIngredient  :001394 ;
         :matchScore            "0.14805194735527"^^xsd:double .
 
-:64bfaed5-82b7-4de9-a641-540b1f9b1e46
+:8c6d86d1-e667-4324-982a-b05f90b6f722
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :camphor_aroma ;
-        :sensoryValue          "7.0"^^xsd:double .
+        :hasSensoryDescriptor  :meaty_aroma ;
+        :sensoryValue          "4.2"^^xsd:double .
+
+:1e625fea-51ef-4dd3-ac46-7e8c857806c6
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :apple_aroma ;
+        :sensoryValue          "0.26"^^xsd:double .
 
 :005675-000013  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Full-fat Yogurt pairing" ;
@@ -31488,11 +31522,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13202263"^^xsd:anyURI ;
         skos:definition         "Juicy, stone fruits with a sweet and fragrant flavor, commonly eaten fresh or used in desserts."@en ;
         skos:prefLabel          "Yellow Peach"@en ;
-        :hasAroma               :9a0ee21e-f192-4860-94fd-c34c9db6cede , :1f2d6423-62f6-4ae2-8c8e-fdaa497a8ba2 , :d98ade27-b6b8-406b-8494-2e64bfbf97d6 , :02f71f96-4e11-438f-95c3-0e5f0786cbaf ;
+        :hasAroma               :df37c31d-90ed-41dc-8ef1-6b6c511d2d22 , :0973c877-bf91-4471-b552-b1e2377cbcbc , :e843b6a8-59ec-4192-8a8f-993607143e8a , :c3a7a317-6308-4434-affd-d449c6f3ff88 ;
         :hasFunctionalBenefit   :Stress , :Brain , :Minerals , :Diabetic , :Digestion , :Antioxidant , :Cardiovascular , :Bone , :Weight-loss , :Immunity , :Energy ;
         :hasIngredientCategory  :icat:000092 ;
-        :hasTaste               :7463a914-26ea-478a-b686-a5be63bf5ef1 , :8aa273e3-b829-4cbf-8fa8-59f6ed1612dc ;
-        :hasTexture             :bb501236-8746-4099-9b30-a6e982f43d28 .
+        :hasTaste               :0b453379-fda4-4656-8c81-ab0ce1a3de9e , :be787008-5953-4b1d-9c2c-c2f9087443c7 ;
+        :hasTexture             :7fd4c457-de1a-4ff7-bbe7-d816860b9f5c .
 
 :005842-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Champignon Mushroom pairing" ;
@@ -31653,6 +31687,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000357 ;
         :matchScore            "0.272727280855179"^^xsd:double .
 
+:70185ac9-b52f-48de-81a7-c6680ce2afc6
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :soft_texture ;
+        :sensoryValue          true .
+
 :005675-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Humulus Shoot pairing" ;
         :hasKeyIngredient      :005675 ;
@@ -31742,11 +31781,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q2164820"^^xsd:anyURI ;
         skos:definition         "Milk chocolate is a smooth, creamy chocolate made from cocoa solids, milk, and sugar, known for its sweet flavor."@en ;
         skos:prefLabel          "Milk Chocolate"@en ;
-        :hasAroma               :c4e26e2e-337d-4e5f-b80b-7d360551f08a , :68fbe466-fbb3-4626-81cd-9fe8261dd949 , :3474f094-524b-422c-a4be-cada032d606f , :92b015e7-adf0-4fad-82d9-e67ddda2244b , :7e5eb2ac-86e5-4e6c-8132-b7657784f435 , :c029a758-917d-447d-a550-b6b5676e1f71 ;
+        :hasAroma               :ee224f9f-0d7d-4fd8-89e5-514619d4819f , :dee4d3b6-7eb1-4aa0-9aac-9860b4eda768 , :8a1cf927-b40e-4511-9983-8ea96e8969af , :1fa6a5d3-4eb3-4623-8ee1-60c4041185c3 , :e3e722ab-94da-4f67-96ec-00c45fc96176 , :542b5f8d-7fec-41f3-baf7-a7fec9ec1427 ;
         :hasFunctionalBenefit   :Energy , :Antioxidant ;
         :hasIngredientCategory  :icat:000004 ;
-        :hasTaste               :04d6b89d-6fe2-4480-8b79-79543c216803 ;
-        :hasTexture             :9d4bb628-ae48-4ffd-94a3-aa91f62a3f4b , :92b2ebdb-3d9f-47fd-8c6c-7490b5faf81d .
+        :hasTaste               :48d86a51-d0af-482f-bd6a-15d1d329ed5d ;
+        :hasTexture             :7568cbce-14db-40c2-bede-04a825d93d1f , :03e01765-899e-4f03-be45-903c8f06920d .
 
 :000155-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Yellow Nectarine pairing" ;
@@ -31782,6 +31821,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000046 ;
         :hasRelatedIngredient  :000182 ;
         :matchScore            "0.0144215533509851"^^xsd:double .
+
+:c18d98fb-284a-4539-b560-d1daaeae536d
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "8.5"^^xsd:double .
 
 :005675  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q4200953"^^xsd:anyURI ;
@@ -31916,16 +31960,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
 :Cardiovascular  rdf:type  :FunctionalBenefit ;
         skos:definition  "Functional benefits for cardiovascular health support the heart and circulatory system, reducing the risk of heart-related conditions." ;
         skos:prefLabel   "Cardiovascular"@en .
-
-:72e8c997-099f-4c3a-8939-dbde05b2d3cf
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :grass_aroma ;
-        :sensoryValue          "0.7000000000000001"^^xsd:double .
-
-:0f289a49-62a8-4e14-bbc7-95ce4c8eea3a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :roasted_aroma ;
-        :sensoryValue          "0.17500000000000002"^^xsd:double .
 
 :000213-000938  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with White Asparagus pairing" ;
@@ -32147,10 +32181,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.131578952074051"^^xsd:double .
 
-:pear_aroma  rdf:type    :SensoryDescriptor ;
-        skos:prefLabel   "pear_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+:pear_aroma  rdf:type   :SensoryDescriptor ;
+        skos:prefLabel  "pear_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :008970-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brewed Coffee with Spinach pairing" ;
@@ -32175,6 +32208,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000082 ;
         :hasRelatedIngredient  :000040 ;
         :matchScore            "0.200000002980232"^^xsd:double .
+
+:c2216f17-02b4-40ad-89e5-b122f77e348d
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :000472-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Camembert with Tequila Silver pairing" ;
@@ -32218,11 +32256,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001959 ;
         :matchScore            "0.0491803288459778"^^xsd:double .
 
-:d371a504-bba7-4cc2-ac42-712fca46b22a
-        rdf:type               :Trigeminal ;
-        :hasSensoryDescriptor  :astringent_trigeminal_taste ;
-        :sensoryValue          true .
-
 :000993-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tabasco with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :000993 ;
@@ -32240,11 +32273,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000159 ;
         :hasRelatedIngredient  :000215 ;
         :matchScore            "0.118811883032322"^^xsd:double .
-
-:453697ed-ce53-474c-b7d4-638b51446f83
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "0.625"^^xsd:double .
 
 :000105-000865  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Green Bean with Sake pairing" ;
@@ -32281,6 +32309,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000865 ;
         :hasRelatedIngredient  :000141 ;
         :matchScore            "0.0625"^^xsd:double .
+
+:a3d0456c-97c3-4e27-aed0-3906545d4ca3
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :bitter_taste ;
+        :sensoryValue          "0.1"^^xsd:double .
 
 :006473-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster with Armagnac pairing" ;
@@ -32348,11 +32381,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.349999994039536"^^xsd:double .
 
-:17f3b4e7-dadd-4ef2-a3c3-1590c4cbfeeb
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :creamy_aroma ;
-        :sensoryValue          "0.4"^^xsd:double .
-
 :005483-000031  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Lemongrass pairing" ;
         :hasKeyIngredient      :005483 ;
@@ -32418,11 +32446,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.072727270424366"^^xsd:double .
 
-:9a4865ad-ffab-4a5a-a658-461ebb3bb19d
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fermented_aroma ;
-        :sensoryValue          "0.55"^^xsd:double .
-
 :000149-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Yellow Nectarine pairing" ;
         :hasKeyIngredient      :000149 ;
@@ -32484,9 +32507,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.341772139072418"^^xsd:double .
 
 :earthy_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "earthy_aroma"@en ;
-        :aromaIntensity  "9.5"^^xsd:double ;
-        :hasAromaType    :roasted .
+        skos:prefLabel  "earthy_aroma"@en ;
+        :hasAromaType   :roasted .
 
 :000920-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Plum pairing" ;
@@ -32680,11 +32702,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000515 ;
         :matchScore            "0.104895107448101"^^xsd:double .
 
-:7aae2b6d-8e95-4386-b16b-ad5ea65a446e
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
-
 :000163-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Spinach pairing" ;
         :hasKeyIngredient      :000163 ;
@@ -32852,11 +32869,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.176377952098846"^^xsd:double .
 
-:b7f9c3e5-aee7-4e51-b086-bf161705f408
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pine_aroma ;
-        :sensoryValue          "0.45"^^xsd:double .
-
 :000142-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Mustard pairing" ;
         :hasKeyIngredient      :000142 ;
@@ -32922,11 +32934,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000136 ;
         :hasRelatedIngredient  :000082 ;
         :matchScore            "0.0767543837428093"^^xsd:double .
-
-:1b2adaf6-0f22-4c85-8879-c096f52c2c72
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :fatty_taste ;
-        :sensoryValue          "0.1"^^xsd:double .
 
 :005509-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Long-Grain Rice with Green Bean pairing" ;
@@ -33060,11 +33067,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.25"^^xsd:double .
 
-:f434d3d5-282d-441c-908e-d8b1a3122051
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "7.2"^^xsd:double .
-
 :000163-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Gruyère pairing" ;
         :hasKeyIngredient      :000163 ;
@@ -33105,11 +33107,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000082 ;
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.100000001490116"^^xsd:double .
-
-:41b2828a-8c27-435a-8cba-cb9f4505216c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :earthy_aroma ;
-        :sensoryValue          "7.6000000000000005"^^xsd:double .
 
 :001448-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with Tequila Silver pairing" ;
@@ -33286,9 +33283,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0444444455206394"^^xsd:double .
 
 :tropical_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "tropical_aroma"@en ;
-        :aromaIntensity  "5.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "tropical_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000515-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster Mushroom with Pumpkin pairing" ;
@@ -33458,6 +33454,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000311 ;
         :matchScore            "0.312956809997559"^^xsd:double .
 
+:0973c877-bf91-4471-b552-b1e2377cbcbc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :honey_aroma ;
+        :sensoryValue          "2.0"^^xsd:double .
+
 :000182-000148  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Celery with Mango pairing" ;
         :hasKeyIngredient      :000182 ;
@@ -33524,10 +33525,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.283983051776886"^^xsd:double .
 
-:apple_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "apple_aroma"@en ;
-        :aromaIntensity  "3.25"^^xsd:double ;
-        :hasAromaType    :fruity .
+:apple_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "apple_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000144-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Gruyère pairing" ;
@@ -33630,11 +33630,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000355 ;
         :matchScore            "0.0754242613911629"^^xsd:double .
 
-:61ccc851-3bd6-4194-a3ba-5ac690887b79
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :mustard_aroma ;
-        :sensoryValue          "3.15"^^xsd:double .
-
 :006821-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Champignon Mushroom pairing" ;
         :hasKeyIngredient      :006821 ;
@@ -33652,11 +33647,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000142 ;
         :hasRelatedIngredient  :006473 ;
         :matchScore            "0.0806451588869095"^^xsd:double .
-
-:14692030-96a9-4a63-b34b-50e1ad61ab4c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "9.0"^^xsd:double .
 
 :000059-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Plum pairing" ;
@@ -33769,10 +33759,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
 
-:293065fd-c510-46a3-b76d-288cea845325
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
+:b90a652c-0be5-41e2-825b-a0277e65fa5e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.25"^^xsd:double .
 
 :000083-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Lime pairing" ;
@@ -33791,11 +33781,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000109 ;
         :hasRelatedIngredient  :005569 ;
         :matchScore            "0.0425144247710705"^^xsd:double .
-
-:dd7c706f-f73e-444e-b3b9-6735d64730cb
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :fatty_taste ;
-        :sensoryValue          "0.4"^^xsd:double .
 
 :000311-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Armagnac pairing" ;
@@ -33821,9 +33806,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0111296605318785"^^xsd:double .
 
 :violet_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "violet_aroma"@en ;
-        :aromaIntensity  "2.5"^^xsd:double ;
-        :hasAromaType    :floral .
+        skos:prefLabel  "violet_aroma"@en ;
+        :hasAromaType   :floral .
 
 :000014-000938  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Boiled Egg with White Asparagus pairing" ;
@@ -33951,10 +33935,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001696 ;
         :matchScore            "0.152941182255745"^^xsd:double .
 
-:peach_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "peach_aroma"@en ;
-        :aromaIntensity  "8.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+:peach_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "peach_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :006821-000801  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Cocoa Powder pairing" ;
@@ -34235,10 +34218,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005754 ;
         :matchScore            "0.163984209299088"^^xsd:double .
 
-:7e5eb2ac-86e5-4e6c-8132-b7657784f435
+:bd68b55d-1042-43f3-afe9-2acc2a765d8c
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :chocolate_aroma ;
-        :sensoryValue          "3.0"^^xsd:double .
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "8.5"^^xsd:double .
 
 :005622-000161  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Scallop Saint Jacques with Watermelon pairing" ;
@@ -34253,9 +34236,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.161333337426186"^^xsd:double .
 
 :strawberry_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "strawberry_aroma"@en ;
-        :aromaIntensity  "8.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "strawberry_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000873-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Red Bell Pepper pairing" ;
@@ -34412,10 +34394,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.194005444645882"^^xsd:double .
 
 :oat_flakes_cereal_aroma
-        rdf:type         :SensoryDescriptor ;
-        skos:prefLabel   "oat_flakes_cereal_aroma"@en ;
-        :aromaIntensity  "0.5"^^xsd:double ;
-        :hasAromaType    :green .
+        rdf:type        :SensoryDescriptor ;
+        skos:prefLabel  "oat_flakes_cereal_aroma"@en ;
+        :hasAromaType   :green .
 
 :000017-000865  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tomato with Sake pairing" ;
@@ -34440,11 +34421,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005675 ;
         :hasRelatedIngredient  :007105 ;
         :matchScore            "0.0481889769434929"^^xsd:double .
-
-:5b23b6a8-d9e1-42d0-9698-ecacf1ebdcdb
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :earthy_aroma ;
-        :sensoryValue          "4.75"^^xsd:double .
 
 :007109-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fig with Acacia Honey pairing" ;
@@ -34494,6 +34470,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.235294118523598"^^xsd:double .
 
+:02825b62-c1c4-4058-b5e7-66c017a727da
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fig_aroma ;
+        :sensoryValue          "0.7000000000000001"^^xsd:double .
+
 :000046-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Blueberry pairing" ;
         :hasKeyIngredient      :000046 ;
@@ -34524,11 +34505,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.0444444455206394"^^xsd:double .
 
-:3cb6749d-fb00-42da-ae30-7054fbbdf6ff
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "8.5"^^xsd:double .
-
 :000107-002530  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Gruyère with Bread pairing" ;
         :hasKeyIngredient      :000107 ;
@@ -34541,10 +34517,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000475 ;
         :matchScore            "0.125"^^xsd:double .
 
-:60b63e20-95fe-4e40-8928-bb4e78d47bc2
+:60a400b9-649f-4c5b-b501-634bd229156e
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :rice_aroma ;
-        :sensoryValue          "0.08750000000000001"^^xsd:double .
+        :hasSensoryDescriptor  :nutty_aroma ;
+        :sensoryValue          "0.30000000000000004"^^xsd:double .
 
 :000475-000887  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pecan Nut with White Chocolate pairing" ;
@@ -34582,10 +34558,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.159999996423721"^^xsd:double .
 
-:df949c44-17c5-4902-a648-18cf5dbdee45
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :creamy_texture ;
-        :sensoryValue          true .
+:1b079b4a-b581-4ade-9805-c689d9e07f73
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "5.949999999999999"^^xsd:double .
 
 :007088-000096  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Armagnac with Chives pairing" ;
@@ -34653,11 +34629,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006002 ;
         :matchScore            "0.00769230769947171"^^xsd:double .
 
-:31fb6623-8255-47fb-bd5a-81817504ec35
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :potato_aroma ;
-        :sensoryValue          "8.100000000000001"^^xsd:double .
-
 :000123-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Rosemary with Avocado pairing" ;
         :hasKeyIngredient      :000123 ;
@@ -34668,10 +34639,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q165308"^^xsd:anyURI ;
         skos:definition         "Vibrant orange squash with a mildly sweet, nutty flavor, used in both savory and sweet recipes, especially during autumn."@en ;
         skos:prefLabel          "Pumpkin"@en ;
-        :hasAroma               :4c3e9632-dc7f-47d6-abe7-69492a801696 , :45a7365e-706a-439a-ae28-5ec45545569b , :9d66b895-5e8a-454f-a7a2-51b1c6cbc834 , :02dd4f80-a76e-4e7f-adfb-ee32427665c1 ;
+        :hasAroma               :f9607212-bdb1-40d5-bd8a-c5b81a0a1c64 , :43353cb4-bca7-48d3-b073-36295a9f8e51 , :23a4aada-4bd6-4a2f-b86c-c00c64a1a81d , :51cae09a-6e03-483e-8be8-5fc84dd43983 ;
         :hasFunctionalBenefit   :Antioxidant , :Bone , :Minerals , :Digestion , :Vitamins , :Brain , :Weight-gain , :Stress , :Energy , :Probiotic , :Diabetic ;
         :hasIngredientCategory  :icat:000129 ;
-        :hasTexture             :7512d918-74df-422c-82f6-78ee15465223 .
+        :hasTexture             :daa2f222-498b-4a67-932f-8cfc05d9e7ce .
 
 :000515-000920  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster Mushroom with Cucumber pairing" ;
@@ -34715,6 +34686,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000136 ;
         :matchScore            "0.226090773940086"^^xsd:double .
 
+:e3f50eab-a3d9-4368-a6a0-c387d012e1d5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :clove_aroma ;
+        :sensoryValue          "3.0"^^xsd:double .
+
 :006821-005760  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Veal pairing" ;
         :hasKeyIngredient      :006821 ;
@@ -34737,11 +34713,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q1093742"^^xsd:anyURI ;
         skos:definition         "Citrus fruit with a sour and tangy flavor, commonly used in cooking, baking, and beverages."@en ;
         skos:prefLabel          "Lemon"@en ;
-        :hasAroma               :e49aec28-5583-4fc5-9af5-e277b7b5b6ec , :7e9ab118-ece5-4372-ab56-b254342faafe ;
+        :hasAroma               :5d7d7690-9504-4d93-bcf6-10fb10647111 , :3bd06ef6-e2dd-488a-a971-73cb9313d22e ;
         :hasFunctionalBenefit   :Antibacterial , :Diabetic , :Stress , :Brain , :Weight-loss , :Prebiotic , :Cardiovascular , :Minerals , :Energy , :Bone , :Immunity , :Antioxidant , :Digestion , :Sleep , :Probiotic ;
         :hasIngredientCategory  :icat:000089 ;
-        :hasTaste               :ef7e9b99-f0ee-43e2-a6cb-0b0b40d88fff , :83e72a66-2c8b-4847-9d85-00e622e753a7 ;
-        :hasTexture             :5bd3d122-e453-4ba8-b6da-83c0733a87ce .
+        :hasTaste               :8f27822f-1d09-4a75-8ba9-8a5668959ab0 , :7de14d63-f922-4e30-842a-eca97b2f98c6 ;
+        :hasTexture             :14e002f9-32e6-44ae-b379-0e20971e7609 .
 
 :001008-000096  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk Chocolate with Chives pairing" ;
@@ -34791,10 +34767,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.0799999982118607"^^xsd:double .
 
-:fig_aroma  rdf:type     :SensoryDescriptor ;
-        skos:prefLabel   "fig_aroma"@en ;
-        :aromaIntensity  "3.5"^^xsd:double ;
-        :hasAromaType    :fruity .
+:fig_aroma  rdf:type    :SensoryDescriptor ;
+        skos:prefLabel  "fig_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :icat:000119  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000023 ;
@@ -34825,21 +34800,15 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000520 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
 
-:spicy_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "spicy_aroma"@en ;
-        :aromaIntensity  "1.5"^^xsd:double ;
-        :hasAromaType    :spicy .
+:spicy_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "spicy_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :000213-001448  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Jasmine Tea pairing" ;
         :hasKeyIngredient      :000213 ;
         :hasRelatedIngredient  :001448 ;
         :matchScore            "0.0939849615097046"^^xsd:double .
-
-:45a7365e-706a-439a-ae28-5ec45545569b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "2.6999999999999997"^^xsd:double .
 
 :007105-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Yellow Grapefruit pairing" ;
@@ -35080,6 +35049,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000787 ;
         :matchScore            "0.215831771492958"^^xsd:double .
 
+:08a4eab8-2c30-4534-91db-2e3dc935068f
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pine_aroma ;
+        :sensoryValue          "6.75"^^xsd:double .
+
 :000886-000801  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Whisky with Cocoa Powder pairing" ;
         :hasKeyIngredient      :000886 ;
@@ -35123,9 +35097,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.193236708641052"^^xsd:double .
 
 :vanilla_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "vanilla_aroma"@en ;
-        :aromaIntensity  "0.75"^^xsd:double ;
-        :hasAromaType    :spicy .
+        skos:prefLabel  "vanilla_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :000021-000306  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Atlantic Salmon pairing" ;
@@ -35175,16 +35148,21 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006821 ;
         :matchScore            "0.139211133122444"^^xsd:double .
 
+:19152386-86d5-419f-bd3f-9e9a8cce9f74
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :tropical_aroma ;
+        :sensoryValue          "12.5"^^xsd:double .
+
+:a357ef15-2e67-4e77-b208-62e0f197454a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :cheesy_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :005483-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Orange pairing" ;
         :hasKeyIngredient      :005483 ;
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.0376623384654522"^^xsd:double .
-
-:02f71f96-4e11-438f-95c3-0e5f0786cbaf
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :peach_aroma ;
-        :sensoryValue          "19.2"^^xsd:double .
 
 :000791-006821  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Calvados with Dark Chocolate pairing" ;
@@ -35208,12 +35186,17 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.136363640427589"^^xsd:double .
 
+:694a0c76-95e9-4ac5-8cd0-278e72f61c4e
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
+
 :008970  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q1155703"^^xsd:anyURI ;
         skos:definition         "Beverage made by steeping ground coffee beans in hot water, known for its stimulating effect."@en ;
         skos:prefLabel          "Brewed Coffee"@en ;
-        :hasAroma               :616e3202-c013-47d7-a558-0b99e0e43298 , :61cd3600-51e6-42a6-9425-b72c3341fcd3 , :4b5e4e23-a35a-48d2-8770-d4dc310f354d , :2096f30d-9642-43e6-b79d-07f4e2d66234 , :db5fd720-e6d7-4237-bd25-a874265eb264 , :6bb07799-bf53-42c5-965b-c0db4f784199 ;
-        :hasFunctionalBenefit   :Sleep , :Weight-gain , :Ageing , :Brain , :Nervous-system , :Digestion , :Diabetic , :Prebiotic , :Vitamins , :Cardiovascular , :Energy , :Minerals , :Antioxidant , :Weight-loss , :Stress , :Skin-health , :Bone ;
+        :hasAroma               :578fc772-7b79-4355-a290-b00977714956 , :152d5814-22d6-42e9-b241-0b82efb13e88 , :1e965169-cb02-466a-a188-0347ebe510ed , :8e8e6d59-d5a4-4d8b-a5bc-bbd264b9756f , :a3387a5e-228e-4462-a21e-750ec59d69d9 , :9649d7de-a8b7-45b7-a39b-c39cc32ebf91 ;
+        :hasFunctionalBenefit   :Sleep , :Weight-gain , :Ageing , :Nervous-system , :Brain , :Digestion , :Diabetic , :Prebiotic , :Vitamins , :Cardiovascular , :Energy , :Minerals , :Antioxidant , :Weight-loss , :Stress , :Skin-health , :Bone ;
         :hasIngredientCategory  :icat:000074 .
 
 :005942-000873  rdf:type       :IngredientPairing ;
@@ -35233,11 +35216,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         skos:definition  "Refers to spices with a bitter taste, often used in small quantities to add complexity and depth of flavor to dishes."@en ;
         skos:prefLabel   "Bitter Spices"@en .
 
-:3f02de85-ba88-43ca-9966-ff2c11c9d1db
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.5"^^xsd:double .
-
 :000013-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Full-fat Yogurt with Calvados pairing" ;
         :hasKeyIngredient      :000013 ;
@@ -35254,11 +35232,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13099586"^^xsd:anyURI ;
         skos:definition         "Juicy, sweet fruits with a crisp texture, commonly eaten fresh or used in desserts."@en ;
         skos:prefLabel          "Pear"@en ;
-        :hasAroma               :7f46ac2c-3356-423e-ac87-11edf7e66b83 , :7e5f8a03-6f4d-436e-a7d0-3c1b234c4118 , :12368e47-6471-48de-9494-fd21139df20e , :4343296c-d45c-41d7-b9dd-14dbc6707f49 ;
+        :hasAroma               :80088143-aa79-43e0-9f09-2878b281dd83 , :bc82ce1f-6421-46f8-a6a8-845ad3d7f196 , :f7f61704-f10e-4de1-8937-ff444f3de966 , :1f6bd86d-1241-47e8-9207-29cbca5064fb ;
         :hasFunctionalBenefit   :Energy , :Bone , :Weight-loss , :Cardiovascular , :Stress , :Digestion , :Antioxidant , :Brain , :Diabetic , :Probiotic , :Sleep , :Minerals ;
         :hasIngredientCategory  :icat:000091 ;
-        :hasTaste               :5334e44e-ac9a-4fe9-b9fd-d2a8cd1a1bd3 ;
-        :hasTexture             :843a8a1f-9578-49ed-83e2-952e174906f7 , :82348c43-7305-4d28-aec7-56dadb1266e5 .
+        :hasTaste               :17772f42-dfd0-42dd-b3b6-f900627c83d1 ;
+        :hasTexture             :2cbe3d44-ab1f-40d9-a6cf-296b97542719 , :2df57f66-4471-4b02-a8bd-8149ce7b3418 .
 
 :000149-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Avocado pairing" ;
@@ -35284,11 +35262,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000117 ;
         :matchScore            "0.0740740746259689"^^xsd:double .
 
-:4f8ff6c9-248c-4940-a1fb-ddce86c258f0
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :berry_aroma ;
-        :sensoryValue          "9.5"^^xsd:double .
-
 :000215-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Avocado pairing" ;
         :hasKeyIngredient      :000215 ;
@@ -35300,6 +35273,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000311 ;
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.192307695746422"^^xsd:double .
+
+:7eedec64-a5e1-4191-92d3-b146038c2d66
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :buttery_aroma ;
+        :sensoryValue          "3.375"^^xsd:double .
 
 :000163-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Oyster Mushroom pairing" ;
@@ -35337,11 +35315,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.241935476660728"^^xsd:double .
 
-:b23a4b03-5488-4a5b-9489-a2ee3bdce450
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :potato_aroma ;
-        :sensoryValue          "0.24"^^xsd:double .
-
 :000163-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Raspberry pairing" ;
         :hasKeyIngredient      :000163 ;
@@ -35364,10 +35337,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q15046077"^^xsd:anyURI ;
         skos:definition         "A spicy and aromatic root commonly used in cooking and known for its distinctive flavor."@en ;
         skos:prefLabel          "Ginger"@en ;
-        :hasAroma               :8361d91b-e32f-44c6-a8b9-0680bb03895e , :5537f907-115a-4c0d-887a-746ecb87d3c5 , :72682989-b1b2-4195-a539-e5da35bf0c3e ;
+        :hasAroma               :c97ce39a-dff9-42f9-a4ad-d52d940fb04f , :49a5e334-6484-46a9-95d9-8840aec15f28 , :7895e199-e08d-474d-9d5e-44fd334920b5 ;
         :hasFunctionalBenefit   :Immunity , :Bone , :Prebiotic , :Stress , :Weight-loss , :Digestion , :Ageing , :Nervous-system , :Minerals , :Vitamins , :Weight-gain , :Antioxidant , :Brain , :Energy , :Sleep , :Antibacterial , :Probiotic , :Cardiovascular , :Diabetic ;
         :hasIngredientCategory  :icat:000115 ;
-        :hasTrigeminal          :63a90b3b-1704-492a-af92-2a34e18c4b74 , :cc1d2af2-0127-44f3-874d-7052e708f941 .
+        :hasTrigeminal          :bd964f2b-3633-4895-bc09-b4a7532e58af , :c9420e93-54fc-423e-adce-d887a773a09c .
 
 :000311-000413  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Apple 'Jonagold' pairing" ;
@@ -35441,11 +35414,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.0343750007450581"^^xsd:double .
 
-:6dee2dfd-3344-426f-8b49-901359cc6faa
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :acidic_aroma ;
-        :sensoryValue          "3.5"^^xsd:double .
-
 :005675-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Baguette pairing" ;
         :hasKeyIngredient      :005675 ;
@@ -35500,16 +35468,20 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.0980392172932625"^^xsd:double .
 
+:808a6e2a-dc72-4232-99a9-c01369d2380c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :roasted_aroma ;
+        :sensoryValue          "0.35000000000000003"^^xsd:double .
+
 :000873-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Acacia Honey pairing" ;
         :hasKeyIngredient      :000873 ;
         :hasRelatedIngredient  :007105 ;
         :matchScore            "0.0759493634104729"^^xsd:double .
 
-:corn_aroma  rdf:type    :SensoryDescriptor ;
-        skos:prefLabel   "corn_aroma"@en ;
-        :aromaIntensity  "4.5"^^xsd:double ;
-        :hasAromaType    :vegetable .
+:corn_aroma  rdf:type   :SensoryDescriptor ;
+        skos:prefLabel  "corn_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000876-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Mayonnaise pairing" ;
@@ -35522,11 +35494,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000135 ;
         :hasRelatedIngredient  :000181 ;
         :matchScore            "0.00713012460619211"^^xsd:double .
-
-:f8d43e2a-9640-48db-8e5a-54505bd0e4f4
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.25"^^xsd:double .
 
 :005509-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Long-Grain Rice with Avocado pairing" ;
@@ -35552,10 +35519,14 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.267567574977875"^^xsd:double .
 
+:e96e0bd3-14ec-4ea1-a4a2-95544baccc5a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "0.8999999999999999"^^xsd:double .
+
 :acidic_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "acidic_aroma"@en ;
-        :aromaIntensity  "3.5"^^xsd:double ;
-        :hasAromaType    :cheesy .
+        skos:prefLabel  "acidic_aroma"@en ;
+        :hasAromaType   :cheesy .
 
 :000144-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Armagnac pairing" ;
@@ -35616,6 +35587,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000252 ;
         :matchScore            "0.0572519078850746"^^xsd:double .
 
+:cc03e435-c362-4be0-b68c-14e8cb467cb4
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :crispy_texture ;
+        :sensoryValue          true .
+
 :000887-005842  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Garlic Puree pairing" ;
         :hasKeyIngredient      :000887 ;
@@ -35633,11 +35609,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000046 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.0633914396166801"^^xsd:double .
-
-:f7af39d9-9c9a-4b39-af18-2ccfd6538096
-        rdf:type               :Trigeminal ;
-        :hasSensoryDescriptor  :astringent_trigeminal_taste ;
-        :sensoryValue          true .
 
 :006821-007109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Fig pairing" ;
@@ -35752,7 +35723,7 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q18966"^^xsd:anyURI ;
         skos:definition         "A type of maize known for its tender, sweet kernels, enjoyed as a vegetable when fresh and often used in a variety of dishes."@en ;
         skos:prefLabel          "Sweet Corn"@en ;
-        :hasAroma               :9ac41ac0-87d1-42ae-9829-78ace2513d1a , :997e39a4-955d-4877-8c43-acb5872ec927 , :2ee333bf-938e-4205-bcb3-61283e5f7351 ;
+        :hasAroma               :132729e4-b118-4183-b362-4574d2584007 , :619295fd-bae2-4866-997f-446e511c5b56 , :ceed3ea6-b12b-4f89-8d65-4510d0ff6c6e ;
         :hasFunctionalBenefit   :Stress , :Energy , :Vitamins , :Antioxidant ;
         :hasIngredientCategory  :icat:000129 .
 
@@ -35761,6 +35732,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000123 ;
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.161764711141586"^^xsd:double .
+
+:73b9c209-a9aa-4279-87b2-691d676e51e1
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "2.8"^^xsd:double .
 
 :003290-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Cow Mozzarella pairing" ;
@@ -35827,10 +35803,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         skos:definition  "Relates to fruits with a central core containing seeds, often sweet and juicy, such as apples, pears, and quinces."@en ;
         skos:prefLabel   "Pome Fruits"@en .
 
-:b2eb5cdd-9926-4aac-86fd-08e73e541752
+:8e97807f-038b-4da4-a7cf-af7327416ef6
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :tea_aroma ;
-        :sensoryValue          "0.55"^^xsd:double .
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "1.25"^^xsd:double .
 
 :000141-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Humulus Shoot pairing" ;
@@ -35946,11 +35922,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000515 ;
         :matchScore            "0.166944906115532"^^xsd:double .
 
-:1c713b2f-c728-4c4d-83a1-f4576eb29982
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pine_aroma ;
-        :sensoryValue          "4.5"^^xsd:double .
-
 :000865-005569  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sake with Pear pairing" ;
         :hasKeyIngredient      :000865 ;
@@ -35992,11 +35963,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.181858658790588"^^xsd:double .
 
-:d5f6c769-87ed-44f2-887d-0cc0c1517927
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "1.575"^^xsd:double .
-
 :000059-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :000059 ;
@@ -36013,7 +35979,7 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q2735883"^^xsd:anyURI ;
         skos:definition         "Crisp, green vegetables with a mild and refreshing flavor, commonly eaten fresh or pickled."@en ;
         skos:prefLabel          "Cucumber"@en ;
-        :hasAroma               :e39ee8e3-3c10-41b6-a434-14af94bfd122 , :3cb6749d-fb00-42da-ae30-7054fbbdf6ff ;
+        :hasAroma               :c18d98fb-284a-4539-b560-d1daaeae536d , :2062884a-2810-4945-bc84-97984efd20f9 ;
         :hasFunctionalBenefit   :Brain , :Stress , :Energy , :Cardiovascular , :Bone , :Nervous-system , :Antioxidant , :Weight-gain , :Immunity , :Minerals , :Digestion , :Probiotic , :Weight-loss , :Prebiotic ;
         :hasIngredientCategory  :icat:000129 .
 
@@ -36034,6 +36000,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000030 ;
         :hasRelatedIngredient  :006471 ;
         :matchScore            "0.418006420135498"^^xsd:double .
+
+:357b5f08-b837-4de6-bbbd-53e8ab2a99d1
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :floral_aroma ;
+        :sensoryValue          "1.05"^^xsd:double .
 
 :000133-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Oyster pairing" ;
@@ -36083,11 +36054,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000865 ;
         :matchScore            "0.134146347641945"^^xsd:double .
 
-:b2d2e1a1-9ee2-4449-8463-e77538ed8ae7
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "1.0"^^xsd:double .
-
 :000148-000886  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mango with Whisky pairing" ;
         :hasKeyIngredient      :000148 ;
@@ -36105,11 +36071,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :008970 ;
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.00213523139245808"^^xsd:double .
-
-:4b364f51-90a9-4b72-9f11-9f2a25edbe07
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :honey_aroma ;
-        :sensoryValue          "1.0"^^xsd:double .
 
 :000311-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mayonnaise with Cantaloupe Melon pairing" ;
@@ -36165,11 +36126,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000876 ;
         :matchScore            "0.104761905968189"^^xsd:double .
 
-:900de077-9305-45ae-b500-32516a8fbf92
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
-
 :000413-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Apple 'Jonagold' with Emmentaler pairing" ;
         :hasKeyIngredient      :000413 ;
@@ -36185,6 +36141,16 @@ dct:created  rdf:type  owl:AnnotationProperty .
 :icat:000017  rdf:type   skos:Concept , :IngredientCategory ;
         skos:definition  "Includes various types of nuts and seeds used as ingredients or snacks."@en ;
         skos:prefLabel   "Nuts And Seeds Category"@en .
+
+:28a0fa55-737a-4924-9ea6-d326d7e362af
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
+:b86cf805-4d6d-479f-92f5-ceff6fa8bf9e
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :hard_texture ;
+        :sensoryValue          true .
 
 :000213-000252  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Sweet Potato pairing" ;
@@ -36262,10 +36228,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q10987"^^xsd:anyURI ;
         skos:definition         "A sweet, natural substance produced by bees from flower nectar, commonly used as a sweetener."@en ;
         skos:prefLabel          "Honey"@en ;
-        :hasAroma               :6c7881d8-51c9-41d4-98c0-a96320534d8d ;
-        :hasFunctionalBenefit   :Diabetic , :Antibacterial , :Digestion , :Probiotic , :Sleep , :Brain , :Nervous-system , :Immunity , :Weight-loss , :Bone , :Energy , :Stress , :Ageing , :Weight-gain , :Vitamins , :Minerals , :Prebiotic , :Cardiovascular , :Antioxidant ;
+        :hasAroma               :e5660f44-eb86-4470-be26-93a86c23318c ;
+        :hasFunctionalBenefit   :Cardiovascular , :Antibacterial , :Diabetic , :Digestion , :Probiotic , :Sleep , :Brain , :Nervous-system , :Immunity , :Weight-loss , :Bone , :Energy , :Stress , :Ageing , :Weight-gain , :Vitamins , :Minerals , :Prebiotic , :Antioxidant ;
         :hasIngredientCategory  :icat:000125 ;
-        :hasTaste               :c84dc400-1c48-4343-9731-40272ed22412 .
+        :hasTaste               :0d6bfa3c-bd3b-4921-863c-60847e4a6bb0 .
 
 :000215-000031  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Lemongrass pairing" ;
@@ -36273,16 +36239,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000031 ;
         :matchScore            "0.16666667163372"^^xsd:double .
 
-:bd17648c-1a6a-4144-8d86-bb74e4377924
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :camphor_aroma ;
-        :sensoryValue          "1.4000000000000001"^^xsd:double .
-
 :000123  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q68315046"^^xsd:anyURI ;
         skos:definition         "A small, fragrant branch of the herb rosemary, used to impart flavor to dishes."@en ;
         skos:prefLabel          "Rosemary"@en ;
-        :hasAroma               :d2bfd320-e377-404b-b545-4a7f3ae27ca5 , :b1972eec-4644-4ebe-aa84-f53cf0fd001a , :f873e085-3a69-4ff5-9f9d-4cdce14ded84 , :15e042c9-23a0-4a83-b6f7-2a0c62d990e2 , :31f385ae-ed61-4ff6-afcc-4d6e1a3987d0 ;
+        :hasAroma               :be238809-990f-41c2-842c-9175626c8066 , :08a4eab8-2c30-4534-91db-2e3dc935068f , :fb298460-208b-4912-a5e8-998f3becdb57 , :3502e2b8-ae76-4f21-a9ad-4f806ce4d910 , :8be1669b-22fb-4a8d-9061-41c0959f383a ;
         :hasFunctionalBenefit   :Digestion , :Cardiovascular , :Nervous-system , :Stress , :Sleep , :Bone , :Immunity , :Antioxidant , :Weight-loss , :Antibacterial , :Energy , :Brain , :Minerals , :Diabetic ;
         :hasIngredientCategory  :icat:000094 .
 
@@ -36317,9 +36278,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.150812059640884"^^xsd:double .
 
 :grapefruit_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "grapefruit_aroma"@en ;
-        :aromaIntensity  "1.25"^^xsd:double ;
-        :hasAromaType    :citrus .
+        skos:prefLabel  "grapefruit_aroma"@en ;
+        :hasAromaType   :citrus .
 
 :000117-000031  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Lemongrass pairing" ;
@@ -36333,6 +36293,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000306 ;
         :matchScore            "0.164643689990044"^^xsd:double .
 
+:ef496209-9e5c-4783-97f6-ddf7f7db3ba6
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :onion_aroma ;
+        :sensoryValue          "3.2"^^xsd:double .
+
 :000876-000993  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Tabasco pairing" ;
         :hasKeyIngredient      :000876 ;
@@ -36344,6 +36309,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000515 ;
         :hasRelatedIngredient  :000021 ;
         :matchScore            "0.0399999991059303"^^xsd:double .
+
+:3179d832-56e0-4434-89d5-4a896599d451
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :001394-000014  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Boiled Egg pairing" ;
@@ -36385,9 +36355,14 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q170219"^^xsd:anyURI ;
         skos:definition         "Sake is a Japanese rice wine with a mild and slightly sweet flavor, commonly consumed as a beverage."@en ;
         skos:prefLabel          "Sake"@en ;
-        :hasAroma               :60b63e20-95fe-4e40-8928-bb4e78d47bc2 , :ac57b093-a79f-4867-a95a-4e4ceb9641ed , :9a4865ad-ffab-4a5a-a658-461ebb3bb19d ;
+        :hasAroma               :fc1f674b-d5be-44ef-8fa3-b538182d2203 , :8a95a5b7-e031-4945-b94b-0c8809779328 , :205c5fdc-8095-4f0f-ad05-5c9b90d6d248 ;
         :hasFunctionalBenefit   :Brain , :Digestion ;
         :hasIngredientCategory  :icat:000009 .
+
+:266aa4a9-b30b-4d5a-b40e-bcda3b8f213f
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
 
 :000938-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Asparagus with Pumpkin pairing" ;
@@ -36448,6 +36423,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :000993 ;
         :matchScore            "0.0020000000949949"^^xsd:double .
+
+:62e7b414-0d4b-4ecc-b7d7-38d0dc386f63
+        rdf:type               :Trigeminal ;
+        :hasSensoryDescriptor  :astringent_trigeminal_taste ;
+        :sensoryValue          true .
 
 :001008-005509  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk Chocolate with Long-Grain Rice pairing" ;
@@ -36555,11 +36535,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000142 ;
         :matchScore            "0.0285714287310839"^^xsd:double .
 
-:d029c774-68b9-40a0-bd7d-e980edcbbfe1
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "0.03"^^xsd:double .
-
 :001218-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :001218 ;
@@ -36638,11 +36613,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.191449820995331"^^xsd:double .
 
-:657baf34-d7c0-47af-ab2a-9cc1ac55981c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pineapple_aroma ;
-        :sensoryValue          "2.25"^^xsd:double .
-
 :000133-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Avocado pairing" ;
         :hasKeyIngredient      :000133 ;
@@ -36697,6 +36667,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000357 ;
         :matchScore            "0.0149253727868199"^^xsd:double .
 
+:e6493be6-c86c-4a3c-9990-aea338c5aad3
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :fatty_taste ;
+        :sensoryValue          "0.3"^^xsd:double .
+
 :007109-006002  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fig with Pasta pairing" ;
         :hasKeyIngredient      :007109 ;
@@ -36720,11 +36695,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000083 ;
         :hasRelatedIngredient  :000104 ;
         :matchScore            "0.0500000007450581"^^xsd:double .
-
-:264e28cf-09b9-4a40-a10e-48918d6aa03e
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :violet_aroma ;
-        :sensoryValue          "0.5"^^xsd:double .
 
 :000083-001008  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Milk Chocolate pairing" ;
@@ -36935,11 +36905,21 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.0294117648154497"^^xsd:double .
 
+:c6d27884-5d0f-4b54-8ba5-fc76763fc48a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :orange_aroma ;
+        :sensoryValue          "7.5"^^xsd:double .
+
 :000920-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Baguette pairing" ;
         :hasKeyIngredient      :000920 ;
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.558928549289703"^^xsd:double .
+
+:7e3f2cf0-1792-4326-8e45-204e77405acf
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :onion_aroma ;
+        :sensoryValue          "8.0"^^xsd:double .
 
 :000157-007105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Acacia Honey pairing" ;
@@ -36952,11 +36932,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         skos:definition         "Smooth, concentrated paste made from roasted garlic cloves, providing a mellow, aromatic essence to a wide range of recipes."@en ;
         skos:prefLabel          "Garlic Puree"@en ;
         :hasIngredientCategory  :icat:000127 .
-
-:4343296c-d45c-41d7-b9dd-14dbc6707f49
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "1.05"^^xsd:double .
 
 :000355-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Corn with Brussels Sprouts pairing" ;
@@ -36982,6 +36957,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.000977777759544551"^^xsd:double .
 
+:3e67f734-9228-4ea3-86c1-2ea04e7c9cf4
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
+
 :000078-000413  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Apple 'Jonagold' pairing" ;
         :hasKeyIngredient      :000078 ;
@@ -37006,11 +36986,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.0970873758196831"^^xsd:double .
 
-:ba5143f1-886b-4243-8cb4-fd8337bde38a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :clove_aroma ;
-        :sensoryValue          "3.0"^^xsd:double .
-
 :000151-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pineapple with Chorizo pairing" ;
         :hasKeyIngredient      :000151 ;
@@ -37028,11 +37003,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003246 ;
         :hasRelatedIngredient  :000021 ;
         :matchScore            "0.0333333350718021"^^xsd:double .
-
-:b2684c46-7baa-4cc4-9585-f24a773fdbd9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "1.05"^^xsd:double .
 
 :000047-000014  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic with Boiled Egg pairing" ;
@@ -37082,10 +37052,9 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.200000002980232"^^xsd:double .
 
-:green_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "green_aroma"@en ;
-        :aromaIntensity  "8.5"^^xsd:double ;
-        :hasAromaType    :green .
+:green_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "green_aroma"@en ;
+        :hasAromaType   :green .
 
 :000876-003143  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Fourme D'Ambert pairing" ;
@@ -37159,11 +37128,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.00649350648745894"^^xsd:double .
 
-:616e3202-c013-47d7-a558-0b99e0e43298
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :roasted_aroma ;
-        :sensoryValue          "0.17500000000000002"^^xsd:double .
-
 :000357-001755  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Cava pairing" ;
         :hasKeyIngredient      :000357 ;
@@ -37182,11 +37146,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000215 ;
         :matchScore            "0.121469780802727"^^xsd:double .
 
-:bada12ff-e2fa-436c-82c8-defb2a34f2e4
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :tropical_aroma ;
-        :sensoryValue          "12.5"^^xsd:double .
-
 :000072-001696  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemon with Grape pairing" ;
         :hasKeyIngredient      :000072 ;
@@ -37198,11 +37157,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005622 ;
         :hasRelatedIngredient  :000110 ;
         :matchScore            "0.0285714287310839"^^xsd:double .
-
-:7aaa7f32-95cd-4d69-9295-22d2557a2b50
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :ethanol_aroma ;
-        :sensoryValue          "20.0"^^xsd:double .
 
 :001755-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cava with Orange pairing" ;
@@ -37241,9 +37195,8 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.06134969368577"^^xsd:double .
 
 :fruity_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "fruity_aroma"@en ;
-        :aromaIntensity  "9.0"^^xsd:double ;
-        :hasAromaType    :fruity .
+        skos:prefLabel  "fruity_aroma"@en ;
+        :hasAromaType   :fruity .
 
 :000357-000091  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Chervil pairing" ;
@@ -37262,6 +37215,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000306 ;
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.251256287097931"^^xsd:double .
+
+:113fc837-e11c-4903-a0fb-e1aa9911b1f2
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :fatty_taste ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000090-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Tequila Silver pairing" ;
@@ -37364,6 +37322,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000107 ;
         :matchScore            "0.188929885625839"^^xsd:double .
 
+:c949f2a5-c2bf-43bb-85cc-543712243b21
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :roasted_aroma ;
+        :sensoryValue          "0.35000000000000003"^^xsd:double .
+
 :000787-000887  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vanilla 'Bourbon' with White Chocolate pairing" ;
         :hasKeyIngredient      :000787 ;
@@ -37418,10 +37381,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.316582918167114"^^xsd:double .
 
-:09535de2-0bdd-4144-8087-a07641673e9f
+:44043348-5d68-43d0-a7f0-f039b839b8fc
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cucumber_aroma ;
-        :sensoryValue          "6.6"^^xsd:double .
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "0.15000000000000002"^^xsd:double .
 
 :000873-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Tequila Silver pairing" ;
@@ -37561,11 +37524,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001448 ;
         :matchScore            "0.0158227849751711"^^xsd:double .
 
-:84504718-20d7-4317-bc45-fa2967711558
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :hard_texture ;
-        :sensoryValue          true .
-
 :005622-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Scallop Saint Jacques with Chorizo pairing" ;
         :hasKeyIngredient      :005622 ;
@@ -37703,11 +37661,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.222222223877907"^^xsd:double .
 
-:3770d841-d340-4dc5-bd51-9a11a35067e4
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :bitter_taste ;
-        :sensoryValue          "0.1"^^xsd:double .
-
 :003246-005930  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cow Mozzarella with Milk pairing" ;
         :hasKeyIngredient      :003246 ;
@@ -37724,10 +37677,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q545985"^^xsd:anyURI ;
         skos:definition         "Pungent condiment made from fermented fish, commonly used in Southeast Asian cuisine for its savory flavor."@en ;
         skos:prefLabel          "Fish Sauce"@en ;
-        :hasAroma               :453697ed-ce53-474c-b7d4-638b51446f83 , :8de3a1e9-f646-4798-9659-3011e7772862 , :c0a46978-c624-4efc-865b-567c8dd50f34 , :3edf0420-e1fd-4d8c-b48f-5bbb767b4010 ;
+        :hasAroma               :3f4693c5-332e-42fc-83e1-418c6a6161d5 , :70dc47e9-062e-4c16-8334-8b313449df98 , :9fd0f3b7-cf43-4540-94d7-62fc2622e61b , :c949f2a5-c2bf-43bb-85cc-543712243b21 ;
         :hasFunctionalBenefit   :Antioxidant , :Energy ;
         :hasIngredientCategory  :icat:000040 ;
-        :hasTaste               :e7a3550b-a234-4963-ba6c-900d58c3c602 , :7730b241-361d-4f21-a584-d60f14894458 .
+        :hasTaste               :91a7760a-9edf-4847-b3f5-4ba51e4434a8 , :cee7ad0a-9016-4ef0-9a5d-0ae6e8f9a832 .
 
 :000078-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Baguette pairing" ;
@@ -37782,6 +37735,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000920 ;
         :matchScore            "0.0399999991059303"^^xsd:double .
 
+:7568cbce-14db-40c2-bede-04a825d93d1f
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :hard_texture ;
+        :sensoryValue          true .
+
 :000055-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Cheddar pairing" ;
         :hasKeyIngredient      :000055 ;
@@ -37817,6 +37775,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000013 ;
         :hasRelatedIngredient  :007109 ;
         :matchScore            "0.278422266244888"^^xsd:double .
+
+:dfb88e11-8393-4eb4-9e07-5d3ef4a3b98c
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "3.0"^^xsd:double .
 
 :005930-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Plum pairing" ;
@@ -37919,16 +37882,16 @@ dct:created  rdf:type  owl:AnnotationProperty .
         skos:definition  "An ingredient is an individual food entity or elaboration thereof (e.g. apple & apple jam)."@en ;
         skos:prefLabel   "Ingredient"@en .
 
-:7c12e8b7-773c-45b1-b071-45115c1dacc9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "0.8500000000000001"^^xsd:double .
-
 :000017-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tomato with Calvados pairing" ;
         :hasKeyIngredient      :000017 ;
         :hasRelatedIngredient  :000791 ;
         :matchScore            "0.125707104802132"^^xsd:double .
+
+:252d3ba9-eec0-429f-a3bd-476833f13c0c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "0.45"^^xsd:double .
 
 :000313-000355  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Sweet Corn pairing" ;
@@ -37942,10 +37905,10 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.0555555559694767"^^xsd:double .
 
-:f1fdd70e-4ba1-4480-84de-78b940aca396
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
+:ceed3ea6-b12b-4f89-8d65-4510d0ff6c6e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pea_aroma ;
+        :sensoryValue          "2.4000000000000004"^^xsd:double .
 
 :000109-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Lime pairing" ;
@@ -38048,6 +38011,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001448 ;
         :matchScore            "0.000321543397149071"^^xsd:double .
 
+:1f6bd86d-1241-47e8-9207-29cbca5064fb
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :floral_aroma ;
+        :sensoryValue          "1.05"^^xsd:double .
+
 :000157-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Baguette pairing" ;
         :hasKeyIngredient      :000157 ;
@@ -38084,6 +38052,11 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.365714281797409"^^xsd:double .
 
+:4add3515-a63d-4754-9367-5ca96f4af659
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :herbal_aroma ;
+        :sensoryValue          "14.0"^^xsd:double .
+
 :001008-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk Chocolate with Mustard pairing" ;
         :hasKeyIngredient      :001008 ;
@@ -38113,11 +38086,6 @@ dct:created  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000107 ;
         :hasRelatedIngredient  :000149 ;
         :matchScore            "0.0195771344006062"^^xsd:double .
-
-:b56fc844-a110-4fdb-92d7-ce2e9aff5bf3
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :onion_aroma ;
-        :sensoryValue          "3.2"^^xsd:double .
 
 :000157-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Cantaloupe Melon pairing" ;
@@ -38229,11 +38197,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000938 ;
         :matchScore            "0.0827586203813553"^^xsd:double .
 
-:28a6c8e1-a8eb-4064-90b7-fc0515f6250c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :grape_aroma ;
-        :sensoryValue          "1.3499999999999999"^^xsd:double .
-
 :000155-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Orange pairing" ;
         :hasKeyIngredient      :000155 ;
@@ -38245,11 +38208,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001755 ;
         :hasRelatedIngredient  :000472 ;
         :matchScore            "0.0500000007450581"^^xsd:double .
-
-:d8b76843-22fd-4045-8f01-19c06fb9d845
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :asparagus_aroma ;
-        :sensoryValue          "14.0"^^xsd:double .
 
 :icat:000045  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000044 ;
@@ -38278,11 +38236,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q8495"^^xsd:anyURI ;
         skos:definition         "A white, nutrient-rich liquid produced by mammals, commonly consumed as a beverage and used in cooking."@en ;
         skos:prefLabel          "Milk"@en ;
-        :hasAroma               :f5930bd4-b4ed-46b7-a91d-924fe7f0cb17 ;
-        :hasFunctionalBenefit   :Antibacterial , :Skin-health , :Energy , :Calcium-source , :Digestion , :Stress , :Weight-gain , :Sleep , :Bone , :Diabetic , :Minerals , :Cardiovascular , :Vitamins , :Brain , :Weight-loss , :Antioxidant , :Probiotic , :Prebiotic , :Nervous-system , :Immunity , :Ageing ;
+        :hasAroma               :49281643-3db9-4237-bb90-a365e4e4c753 ;
+        :hasFunctionalBenefit   :Antibacterial , :Skin-health , :Energy , :Calcium-source , :Stress , :Digestion , :Weight-gain , :Sleep , :Bone , :Diabetic , :Minerals , :Cardiovascular , :Vitamins , :Brain , :Weight-loss , :Antioxidant , :Probiotic , :Prebiotic , :Nervous-system , :Immunity , :Ageing ;
         :hasIngredientCategory  :icat:000050 ;
-        :hasTaste               :ecbfd8c4-e6ca-4148-9bb4-b913c3e33132 ;
-        :hasTexture             :dc4f0864-2f81-474a-8604-1d5d728570b0 .
+        :hasTaste               :969322ea-02cd-46d8-825a-a871d3b05194 ;
+        :hasTexture             :b0d82819-d25c-498f-9ce9-1b3738d0e310 .
 
 :000993-000306  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tabasco with Atlantic Salmon pairing" ;
@@ -38301,6 +38259,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003246 ;
         :hasRelatedIngredient  :000059 ;
         :matchScore            "0.111111111938953"^^xsd:double .
+
+:fc1f674b-d5be-44ef-8fa3-b538182d2203
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :rice_aroma ;
+        :sensoryValue          "0.08750000000000001"^^xsd:double .
 
 :000078-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Mayonnaise pairing" ;
@@ -38366,11 +38329,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q10817602"^^xsd:anyURI ;
         skos:definition         "Pineapples are tropical fruits with a spiky skin and a sweet, tangy flavor, commonly eaten fresh or used in desserts."@en ;
         skos:prefLabel          "Pineapple"@en ;
-        :hasAroma               :c890b04f-f230-44b6-9220-52c0570a0bce , :550b26fb-58c4-4516-8e47-2069f7144436 , :72e8c997-099f-4c3a-8939-dbde05b2d3cf , :aecd2d6f-9d2d-427f-86e7-a85c4dbca34f ;
+        :hasAroma               :0b985d76-75d3-4c0e-8118-bc0b223ea4c8 , :252d3ba9-eec0-429f-a3bd-476833f13c0c , :358c5467-d4e3-4135-adc1-cd53a82c1791 , :7caf1b37-7fdb-4ba8-864f-344c98de55b4 ;
         :hasFunctionalBenefit   :Diabetic , :Probiotic , :Weight-gain , :Antioxidant , :Stress , :Vitamins , :Minerals , :Digestion , :Energy , :Prebiotic , :Immunity , :Antibacterial ;
         :hasIngredientCategory  :icat:000093 ;
-        :hasTaste               :d992fc4f-5844-4e90-8b89-855a459868cc , :92384141-ff9e-4b2a-8ce0-5cbf39226085 ;
-        :hasTexture             :7aae2b6d-8e95-4386-b16b-ad5ea65a446e .
+        :hasTaste               :58b09313-6b3a-4d7e-8a65-10831d3457fb , :4d7528aa-9a4c-4427-89ef-389dd8380b68 ;
+        :hasTexture             :e67e5c22-4a35-40b8-b3e6-afbedc8e7b0f .
 
 :000133-000161  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Strawberry with Watermelon pairing" ;
@@ -38401,6 +38364,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003246 ;
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.222222223877907"^^xsd:double .
+
+:19cb2584-9f60-4a07-8f4d-854d7a8b1d52
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :mustard_aroma ;
+        :sensoryValue          "3.15"^^xsd:double .
 
 :005483-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Emmentaler pairing" ;
@@ -38495,6 +38463,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000313 ;
         :hasRelatedIngredient  :000865 ;
         :matchScore            "0.454545468091965"^^xsd:double .
+
+:142c1b58-7b71-43a8-8f84-197b766bd751
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
 
 :000090-003143  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Fourme D'Ambert pairing" ;
@@ -38621,11 +38594,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000163 ;
         :matchScore            "0.142857149243355"^^xsd:double .
 
-:3449ae5e-3d64-4cac-9f0e-e2160830231b
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "0.6000000000000001"^^xsd:double .
-
 :000801-000472  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Camembert pairing" ;
         :hasKeyIngredient      :000801 ;
@@ -38672,7 +38640,7 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q61046162"^^xsd:anyURI ;
         skos:definition         "Chives are thin, green herbs with a mild onion flavor, often used as a garnish or flavoring in various dishes."@en ;
         skos:prefLabel          "Chives"@en ;
-        :hasAroma               :8280ff28-200f-42b7-a01c-7f6ce3b75849 , :50e8e8b9-5ecc-4a4d-aafd-1f839481cecd , :c25415b5-f09d-4e51-92c8-819cd0670b82 , :35fafdfc-61c3-4d8e-beff-a5b384cf7ace ;
+        :hasAroma               :add49d36-b6d6-43c0-9786-c548edcc800b , :207376be-3bcd-4c5b-8e86-4c6ff0918625 , :953918d1-47b7-4ddf-b679-bd1156268f8a , :7e3f2cf0-1792-4326-8e45-204e77405acf ;
         :hasFunctionalBenefit   :Antioxidant ;
         :hasIngredientCategory  :icat:000094 .
 
@@ -38687,11 +38655,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000072 ;
         :hasRelatedIngredient  :000083 ;
         :matchScore            "0.111111111938953"^^xsd:double .
-
-:346c8448-4516-46a8-85a1-54ee59a54f65
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :buttery_aroma ;
-        :sensoryValue          "3.375"^^xsd:double .
 
 :001696-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grape with Lemon pairing" ;
@@ -38741,15 +38704,14 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000993 ;
         :matchScore            "0.00634920643642545"^^xsd:double .
 
-:ac57b093-a79f-4867-a95a-4e4ceb9641ed
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fruity_aroma ;
-        :sensoryValue          "0.9"^^xsd:double .
+:egg_aroma  rdf:type    :SensoryDescriptor ;
+        skos:prefLabel  "egg_aroma"@en ;
+        :hasAromaType   :cheesy .
 
-:egg_aroma  rdf:type     :SensoryDescriptor ;
-        skos:prefLabel   "egg_aroma"@en ;
-        :aromaIntensity  "2.0"^^xsd:double ;
-        :hasAromaType    :cheesy .
+:96513123-f930-4594-adce-55b096e3a9ca
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :creamy_texture ;
+        :sensoryValue          true .
 
 :000159-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Grapefruit with Lemon pairing" ;
@@ -38809,6 +38771,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000017 ;
         :matchScore            "0.0388888902962208"^^xsd:double .
 
+:4420a489-6bc9-4ee5-bdbb-5a82dd59fbe9
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "0.3"^^xsd:double .
+
 :000151-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pineapple with Emmentaler pairing" ;
         :hasKeyIngredient      :000151 ;
@@ -38822,9 +38789,8 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.302941173315048"^^xsd:double .
 
 :mushroom_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "mushroom_aroma"@en ;
-        :aromaIntensity  "1.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "mushroom_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000215-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Beetroot with Orange pairing" ;
@@ -38832,10 +38798,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.0555555559694767"^^xsd:double .
 
-:20aa6bf6-c6a6-42f5-bbe5-4a830d5d107f
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pineapple_aroma ;
-        :sensoryValue          "2.25"^^xsd:double .
+:570cfeef-c0d4-4ab1-b021-003af2f32efc
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "0.2"^^xsd:double .
 
 :000357-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Green Bean pairing" ;
@@ -38855,19 +38821,14 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.0674805194139481"^^xsd:double .
 
-:03478de7-b62c-4bfa-921c-48c93a693df7
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "8.5"^^xsd:double .
-
 :000059  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q23900272"^^xsd:anyURI ;
         skos:definition         "A cruciferous vegetable known for its mild flavor and versatility in cooking."@en ;
         skos:prefLabel          "Cauliflower"@en ;
-        :hasAroma               :61ccc851-3bd6-4194-a3ba-5ac690887b79 , :de636813-d689-4801-ac54-9e5b99db123c ;
+        :hasAroma               :19cb2584-9f60-4a07-8f4d-854d7a8b1d52 , :214643c4-3772-42fc-a206-35b44e479bc1 ;
         :hasFunctionalBenefit   :Brain , :Immunity , :Energy , :Antioxidant , :Bone , :Digestion , :Stress ;
         :hasIngredientCategory  :icat:000128 ;
-        :hasTexture             :4665e287-f5c6-49e7-8221-f115bdbfdce8 .
+        :hasTexture             :c34497d5-0609-4196-9152-9128e5dd4f6f .
 
 :000252-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Potato with Sweet Vermouth pairing" ;
@@ -38959,11 +38920,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003143 ;
         :matchScore            "0.108540922403336"^^xsd:double .
 
-:6b89c963-5c5d-4255-860a-825c5d45f888
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "1.7000000000000002"^^xsd:double .
-
 :007170-000109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Basil Leaf pairing" ;
         :hasKeyIngredient      :007170 ;
@@ -39034,7 +38990,7 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q20856764"^^xsd:anyURI ;
         skos:definition         "Coriander seeds are the dried fruits of the coriander plant, imparting a warm, citrusy flavor to dishes and frequently used in spice blends."@en ;
         skos:prefLabel          "Coriander Seed"@en ;
-        :hasAroma               :321f94f1-30e0-489c-aa68-4ed2c465ccbe , :fd3467b4-22a2-4e4e-a005-d89ad3825408 , :796e6b40-6a05-4652-875e-bb29fd083291 , :45b06c8b-9101-4768-a1af-8126e757bb9b ;
+        :hasAroma               :7a3ceda1-5763-4edc-a6e7-64a38ce976dd , :82eb35f6-1fba-4054-b7a8-245e72aa3612 , :20b86595-8d65-4828-89a0-850db345505d , :369d88ce-0409-466b-98ae-84bc1c5d4306 ;
         :hasFunctionalBenefit   :Antioxidant , :Energy , :Stress , :Weight-loss , :Diabetic , :Weight-gain , :Cardiovascular , :Probiotic , :Brain ;
         :hasIngredientCategory  :icat:000115 .
 
@@ -39060,9 +39016,9 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q21281535"^^xsd:anyURI ;
         skos:definition         "Delicate herb with a mild, anise-like flavor, used to add a fresh and aromatic touch to dishes."@en ;
         skos:prefLabel          "Chervil"@en ;
-        :hasAroma               :b43995df-bdf8-478a-9127-616b484c1873 , :bc0d89ef-8ac6-474f-9829-76589588deed ;
+        :hasAroma               :887ef3a2-8a43-44c2-b5f5-7eba3805b193 , :5929269e-4a86-4100-a876-6c65617e2419 ;
         :hasIngredientCategory  :icat:000094 ;
-        :hasTrigeminal          :20a162c2-402e-4eab-8dcc-1c1c00044bdf .
+        :hasTrigeminal          :a1c15074-bb35-4bd6-b31e-2797aff66679 .
 
 :000040-000135  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Raspberry pairing" ;
@@ -39178,9 +39134,8 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0666666701436043"^^xsd:double .
 
 :camphor_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "camphor_aroma"@en ;
-        :aromaIntensity  "14.0"^^xsd:double ;
-        :hasAromaType    :spicy .
+        skos:prefLabel  "camphor_aroma"@en ;
+        :hasAromaType   :spicy .
 
 :001394-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Popcorn with Armagnac pairing" ;
@@ -39308,6 +39263,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000515 ;
         :matchScore            "0.0774907767772675"^^xsd:double .
 
+:60339205-8777-41f2-8ede-872e79a28a77
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :grapefruit_aroma ;
+        :sensoryValue          "3.75"^^xsd:double .
+
 :000105-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Green Bean with Avocado pairing" ;
         :hasKeyIngredient      :000105 ;
@@ -39369,9 +39329,8 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.0546125471591949"^^xsd:double .
 
 :roasted_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "roasted_aroma"@en ;
-        :aromaIntensity  "1.75"^^xsd:double ;
-        :hasAromaType    :roasted .
+        skos:prefLabel  "roasted_aroma"@en ;
+        :hasAromaType   :roasted .
 
 :000413-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Apple 'Jonagold' with Tequila Silver pairing" ;
@@ -39553,10 +39512,9 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.160615384578705"^^xsd:double .
 
-:grass_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "grass_aroma"@en ;
-        :aromaIntensity  "7.0"^^xsd:double ;
-        :hasAromaType    :green .
+:grass_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "grass_aroma"@en ;
+        :hasAromaType   :green .
 
 :000083-000452  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Pumpkin pairing" ;
@@ -39580,11 +39538,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q20638126"^^xsd:anyURI ;
         skos:definition         "A red, yellowish, green, or even purple fruit with a juicy pulp, commonly used in salads, sauces, and various culinary dishes."@en ;
         skos:prefLabel          "Tomato"@en ;
-        :hasAroma               :99855dd8-48f4-476b-ae11-95e05ecdaaf5 , :53c47c69-c7c1-46f8-b1f4-83e67afe6987 ;
+        :hasAroma               :37960029-32a6-4ac3-961e-47f3b48cb9cb , :1b079b4a-b581-4ade-9805-c689d9e07f73 ;
         :hasFunctionalBenefit   :Sleep , :Stress , :Diabetic , :Immunity , :Bone , :Satiety , :Cardiovascular , :Ageing , :Antioxidant , :Energy , :Weight-gain , :Vitamins , :Weight-loss , :Digestion , :Brain , :Nervous-system , :Minerals ;
         :hasIngredientCategory  :icat:000129 ;
-        :hasTaste               :58cf35fd-33f3-4b98-8df8-a94188e37b6e ;
-        :hasTexture             :e2b0f424-5585-4bcf-a963-14d0c06d6740 .
+        :hasTaste               :0064a81d-3d3b-425e-930b-8d36213b7dee ;
+        :hasTexture             :1a0ac4c2-d4dc-41b5-8c60-134ca1954a39 .
 
 :000801-000013  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Full-fat Yogurt pairing" ;
@@ -39693,11 +39651,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :008970 ;
         :matchScore            "0.0185185186564922"^^xsd:double .
 
-:c533bb50-907e-4ab4-9764-27c0b3e23902
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :crunchy_texture ;
-        :sensoryValue          true .
-
 :000475-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pecan Nut with Cow Mozzarella pairing" ;
         :hasKeyIngredient      :000475 ;
@@ -39711,9 +39664,8 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.00375939859077334"^^xsd:double .
 
 :popcorn_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "popcorn_aroma"@en ;
-        :aromaIntensity  "1.75"^^xsd:double ;
-        :hasAromaType    :roasted .
+        skos:prefLabel  "popcorn_aroma"@en ;
+        :hasAromaType   :roasted .
 
 :000078-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Avocado with Yellow Grapefruit pairing" ;
@@ -39733,11 +39685,21 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.142857149243355"^^xsd:double .
 
+:02b08600-786c-4db8-aeea-fd4c38ae7580
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :crunchy_texture ;
+        :sensoryValue          true .
+
 :000281-000105  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Green Bean pairing" ;
         :hasKeyIngredient      :000281 ;
         :hasRelatedIngredient  :000105 ;
         :matchScore            "0.0555555559694767"^^xsd:double .
+
+:654a3f39-996f-42f8-998f-9eb0b459c1ab
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pine_aroma ;
+        :sensoryValue          "4.5"^^xsd:double .
 
 :000123-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Rosemary with Chorizo pairing" ;
@@ -39762,6 +39724,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000110 ;
         :hasRelatedIngredient  :000107 ;
         :matchScore            "0.112499997019768"^^xsd:double .
+
+:0e6fafb5-5926-4205-85a2-99ae9f5325d5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :bell_pepper_aroma ;
+        :sensoryValue          "1.7999999999999998"^^xsd:double .
 
 :000144-000159  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Yellow Grapefruit pairing" ;
@@ -39792,6 +39759,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.100000001490116"^^xsd:double .
+
+:f7bf4dd9-caa0-4378-87ed-290162b02894
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "1.8"^^xsd:double .
 
 :000801-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cocoa Powder with Humulus Shoot pairing" ;
@@ -39901,11 +39873,21 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005760 ;
         :matchScore            "0.203896105289459"^^xsd:double .
 
+:4d7528aa-9a4c-4427-89ef-389dd8380b68
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "3.0"^^xsd:double .
+
 :000031-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemongrass with Humulus Shoot pairing" ;
         :hasKeyIngredient      :000031 ;
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.0133333336561918"^^xsd:double .
+
+:170dd8ff-e7a9-4573-ad20-96a64e7e9ad5
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "1.3"^^xsd:double .
 
 :005930-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Armagnac pairing" ;
@@ -39942,6 +39924,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000149 ;
         :hasRelatedIngredient  :000110 ;
         :matchScore            "0.15950919687748"^^xsd:double .
+
+:c7738211-2afe-46db-a768-300ee3a670c1
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "1.25"^^xsd:double .
 
 :000213-000141  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Yellow Peach pairing" ;
@@ -40032,6 +40019,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000163 ;
         :hasRelatedIngredient  :000117 ;
         :matchScore            "0.00857142824679613"^^xsd:double .
+
+:189f2af8-410b-4c03-b87d-843457a910cc
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :potato_aroma ;
+        :sensoryValue          "8.100000000000001"^^xsd:double .
 
 :000136-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Chorizo pairing" ;
@@ -40158,10 +40150,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000311 ;
         :matchScore            "0.0116550112143159"^^xsd:double .
 
-:f0ffa4b0-7cee-41a1-b8b8-4ab35ca091d7
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
+:207376be-3bcd-4c5b-8e86-4c6ff0918625
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :garlic_aroma ;
+        :sensoryValue          "16.0"^^xsd:double .
 
 :000357-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Mustard pairing" ;
@@ -40205,6 +40197,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.158646613359451"^^xsd:double .
 
+:1e551577-54ab-42da-a1ce-cb887934db7c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :camphor_aroma ;
+        :sensoryValue          "7.0"^^xsd:double .
+
 :000104-000144  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Plum pairing" ;
         :hasKeyIngredient      :000104 ;
@@ -40228,11 +40225,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001755 ;
         :hasRelatedIngredient  :006821 ;
         :matchScore            "0.105999998748302"^^xsd:double .
-
-:584a3b40-5e70-4867-827d-e886f6cd3821
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pine_aroma ;
-        :sensoryValue          "1.8"^^xsd:double .
 
 :000181-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Sweet Cherry pairing" ;
@@ -40420,6 +40412,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.736334383487701"^^xsd:double .
 
+:4eacb6c5-29f5-45b0-bb52-3d49392d8204
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :rose_aroma ;
+        :sensoryValue          "2.5"^^xsd:double .
+
 :000148-005942  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mango with Baguette pairing" ;
         :hasKeyIngredient      :000148 ;
@@ -40521,11 +40518,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         skos:definition  "Relates to distilled alcoholic beverages made from fermented grain mash, aged in wooden casks, and varying in flavor profiles."@en ;
         skos:prefLabel   "Whisky"@en .
 
-:9ac41ac0-87d1-42ae-9829-78ace2513d1a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pea_aroma ;
-        :sensoryValue          "2.4000000000000004"^^xsd:double .
-
 :006471-007109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Carrot with Fig pairing" ;
         :hasKeyIngredient      :006471 ;
@@ -40591,11 +40583,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000148 ;
         :hasRelatedIngredient  :000163 ;
         :matchScore            "0.0750000029802322"^^xsd:double .
-
-:8a5e16b2-1d59-4379-a3fd-3533f53b2b4d
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
 
 :000159-000123  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Grapefruit with Rosemary pairing" ;
@@ -40706,11 +40693,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000520 ;
         :matchScore            "0.355263143777847"^^xsd:double .
 
-:abd81da5-eee7-4943-bd24-a40c74e89fd9
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
-
 :000865-000791  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sake with Calvados pairing" ;
         :hasKeyIngredient      :000865 ;
@@ -40735,11 +40717,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.177419349551201"^^xsd:double .
 
-:33d89b13-f928-4741-b337-73f0ae499543
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :melon_aroma ;
-        :sensoryValue          "1.7999999999999998"^^xsd:double .
-
 :000313-000151  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Honey with Pineapple pairing" ;
         :hasKeyIngredient      :000313 ;
@@ -40752,10 +40729,15 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000148 ;
         :matchScore            "0.333333343267441"^^xsd:double .
 
-:2cf87378-f57a-4697-814c-b5ed3e71c776
+:c7cb9ead-ddde-4044-9a0a-cebe4b0c60bb
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :creamy_aroma ;
-        :sensoryValue          "0.6"^^xsd:double .
+        :hasSensoryDescriptor  :fatty_aroma ;
+        :sensoryValue          "0.6000000000000001"^^xsd:double .
+
+:62cc403e-eeb6-444f-972d-b2a47b9c2681
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :animal_aroma ;
+        :sensoryValue          "0.105"^^xsd:double .
 
 :006002-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pasta with Chorizo pairing" ;
@@ -40883,11 +40865,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q841156"^^xsd:anyURI ;
         skos:definition         "Yellow nectarines are similar to peaches but have smooth skin and a sweet, juicy flavor."@en ;
         skos:prefLabel          "Yellow Nectarine"@en ;
-        :hasAroma               :50af1626-c68d-4ff2-afcb-cd58b2253024 , :6147246a-d307-425b-a8fb-40ef58bfd16a , :081ad76b-a30c-4772-8c39-9ee0e20abb84 , :e679a9c2-c73d-4903-957b-373781b169b8 ;
+        :hasAroma               :c636a3df-0e66-4d20-abee-d179cc8c7132 , :8f2d4762-1d7e-4aa7-9fc4-70515081ae9e , :480589a9-da9c-4481-b23b-3e8ced5d2af3 , :1f70ad19-729f-45c7-a611-8b47243c9bfc ;
         :hasFunctionalBenefit   :Stress , :Energy ;
         :hasIngredientCategory  :icat:000092 ;
-        :hasTaste               :92e9e5dd-8445-44a5-8eae-0a4a99ab2b44 , :67443454-38e0-443b-9573-54bfb2a4d3d2 ;
-        :hasTexture             :072fcf01-ec9d-4888-9209-0d53adc556af .
+        :hasTaste               :f7aa77fd-7595-40cf-9283-278e77cced8f , :dfb88e11-8393-4eb4-9e07-5d3ef4a3b98c ;
+        :hasTexture             :2ce407a1-746a-40f8-b842-f0031fb8b0ce .
 
 :001448-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with Oyster Mushroom pairing" ;
@@ -40901,10 +40883,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001218 ;
         :matchScore            "0.0580046400427818"^^xsd:double .
 
-:dcaa1e77-1f23-4972-be54-aec6490dbf25
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
+:5acb8ddf-db40-4f32-9ae5-c4f50a8fa627
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "7.2"^^xsd:double .
 
 :000151-000876  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pineapple with Sweet Vermouth pairing" ;
@@ -41038,11 +41020,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003143 ;
         :matchScore            "0.428571432828903"^^xsd:double .
 
-:8318cdf0-9fff-4670-828f-ecf558616562
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "8.5"^^xsd:double .
-
 :000149-000013  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Full-fat Yogurt pairing" ;
         :hasKeyIngredient      :000149 ;
@@ -41085,11 +41062,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000938 ;
         :matchScore            "0.0181818176060915"^^xsd:double .
 
-:af8d3edb-25c5-48a4-9da6-b3542f0faaca
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "1.875"^^xsd:double .
-
 :001959-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Grappa with Sweet Cherry pairing" ;
         :hasKeyIngredient      :001959 ;
@@ -41114,6 +41086,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000801 ;
         :hasRelatedIngredient  :000101 ;
         :matchScore            "0.27118644118309"^^xsd:double .
+
+:80088143-aa79-43e0-9f09-2878b281dd83
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pear_aroma ;
+        :sensoryValue          "10.5"^^xsd:double .
 
 :000136-000148  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Mango pairing" ;
@@ -41186,6 +41163,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000133 ;
         :matchScore            "0.35197988152504"^^xsd:double .
 
+:08909c24-572f-41fe-9af2-2641ab3dce48
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :005675-000149  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Banana pairing" ;
         :hasKeyIngredient      :005675 ;
@@ -41203,11 +41185,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :006002 ;
         :hasRelatedIngredient  :001696 ;
         :matchScore            "0.0425531901419163"^^xsd:double .
-
-:3dc7f22c-9cf0-4c62-97fe-abae7ea12bb6
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "3.0"^^xsd:double .
 
 :000357-000133  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oregano with Strawberry pairing" ;
@@ -41742,6 +41719,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000993 ;
         :matchScore            "0.0976827070116997"^^xsd:double .
 
+:fd920290-7949-4394-829d-7ac7180733b9
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.5"^^xsd:double .
+
 :006473-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster with Blueberry pairing" ;
         :hasKeyIngredient      :006473 ;
@@ -41765,6 +41747,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000148 ;
         :hasRelatedIngredient  :006002 ;
         :matchScore            "0.0375000014901161"^^xsd:double .
+
+:4b327663-c8e4-4686-99b8-e25ec916f530
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "1.575"^^xsd:double .
 
 :005930-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk with Cow Mozzarella pairing" ;
@@ -41850,6 +41837,16 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000021 ;
         :matchScore            "0.0405405387282372"^^xsd:double .
 
+:f6828a39-0dc9-4220-976a-114fef2f7800
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "0.09"^^xsd:double .
+
+:a9bd1fa8-477d-4b30-9e4e-dff95b690a71
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :spicy_aroma ;
+        :sensoryValue          "0.22499999999999998"^^xsd:double .
+
 :000155-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Red Bell Pepper pairing" ;
         :hasKeyIngredient      :000155 ;
@@ -41923,6 +41920,16 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001448 ;
         :matchScore            "0.296296298503876"^^xsd:double .
 
+:a3339e3e-6c05-4548-b169-fdfa2bf1008c
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :popcorn_aroma ;
+        :sensoryValue          "0.17500000000000002"^^xsd:double .
+
+:7895e199-e08d-474d-9d5e-44fd334920b5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :lemon_aroma ;
+        :sensoryValue          "0.75"^^xsd:double .
+
 :000101-000055  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Emmentaler with Chorizo pairing" ;
         :hasKeyIngredient      :000101 ;
@@ -41965,11 +41972,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000021 ;
         :matchScore            "0.0297029707580805"^^xsd:double .
 
-:c4e26e2e-337d-4e5f-b80b-7d360551f08a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "0.9"^^xsd:double .
-
 :005760-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Humulus Shoot pairing" ;
         :hasKeyIngredient      :005760 ;
@@ -41987,11 +41989,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000046 ;
         :hasRelatedIngredient  :000104 ;
         :matchScore            "0.0206022188067436"^^xsd:double .
-
-:f3e84a3e-d9fb-44e4-9c71-e580680dc1f4
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cheesy_aroma ;
-        :sensoryValue          "0.375"^^xsd:double .
 
 :000046-001008  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Milk Chocolate pairing" ;
@@ -42178,6 +42175,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :007109 ;
         :matchScore            "0.150000005960464"^^xsd:double .
 
+:e843b6a8-59ec-4192-8a8f-993607143e8a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :peach_aroma ;
+        :sensoryValue          "19.2"^^xsd:double .
+
 :000520-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brussels Sprouts with Spinach pairing" ;
         :hasKeyIngredient      :000520 ;
@@ -42220,15 +42222,9 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000046 ;
         :matchScore            "0.0352941192686558"^^xsd:double .
 
-:d355da8c-e470-45e5-b0ce-a30345d8975c
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :orange_aroma ;
-        :sensoryValue          "3.75"^^xsd:double .
-
 :orange_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "orange_aroma"@en ;
-        :aromaIntensity  "1.25"^^xsd:double ;
-        :hasAromaType    :citrus .
+        skos:prefLabel  "orange_aroma"@en ;
+        :hasAromaType   :citrus .
 
 :000141-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with Pea pairing" ;
@@ -42276,10 +42272,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q131748"^^xsd:anyURI ;
         skos:definition         "Pungent condiment made from ground mustard seeds, commonly used to add flavor and heat to dishes."@en ;
         skos:prefLabel          "Mustard"@en ;
-        :hasAroma               :763edcb4-0367-452f-867f-de90a0b78140 , :6dee2dfd-3344-426f-8b49-901359cc6faa ;
+        :hasAroma               :6a7f17c4-87bd-4cff-a914-8c53e8eb58ad , :1026b9e4-3204-4488-bc1d-37963d197946 ;
         :hasFunctionalBenefit   :Weight-loss , :Immunity , :Diabetic , :Stress , :Digestion , :Minerals , :Nervous-system , :Weight-gain , :Brain , :Cardiovascular , :Antioxidant , :Sleep , :Energy , :Probiotic , :Bone ;
         :hasIngredientCategory  :icat:000040 ;
-        :hasTaste               :b2d2e1a1-9ee2-4449-8463-e77538ed8ae7 .
+        :hasTaste               :120419d8-b9c4-4bdb-9b12-e10de8f94282 .
 
 :001448-000413  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with Apple 'Jonagold' pairing" ;
@@ -42329,10 +42325,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005842 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
 
-:ca6b187b-58a7-4c5a-8fb3-b3d3e9e2c420
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :almond_aroma ;
-        :sensoryValue          "1.3499999999999999"^^xsd:double .
+:daa2f222-498b-4a67-932f-8cfc05d9e7ce
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :starchy_texture ;
+        :sensoryValue          true .
 
 :005942-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Turkey pairing" ;
@@ -42358,11 +42354,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.0222222227603197"^^xsd:double .
 
-:aecd2d6f-9d2d-427f-86e7-a85c4dbca34f
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pineapple_aroma ;
-        :sensoryValue          "13.5"^^xsd:double .
-
 :000059-005675  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cauliflower with Turkey pairing" ;
         :hasKeyIngredient      :000059 ;
@@ -42380,11 +42371,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000133 ;
         :hasRelatedIngredient  :001696 ;
         :matchScore            "0.254010289907455"^^xsd:double .
-
-:a82fd946-a877-41ec-bc48-a91b6e7e06ad
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "2.25"^^xsd:double .
 
 :000281-000078  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Avocado pairing" ;
@@ -42410,11 +42396,21 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         skos:definition  "An aroma refers to the collective scent of ingredients, such as passion fruit. It comprises aroma molecules, each possessing a distinct smell, like a lactone that imparts a peach-like fragrance."@en ;
         skos:prefLabel   "Aroma"@en .
 
+:fb298460-208b-4912-a5e8-998f3becdb57
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "0.75"^^xsd:double .
+
 :000021-000311  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fish Sauce with Mayonnaise pairing" ;
         :hasKeyIngredient      :000021 ;
         :hasRelatedIngredient  :000311 ;
         :matchScore            "0.0058823530562222"^^xsd:double .
+
+:c3a7a317-6308-4434-affd-d449c6f3ff88
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
 
 :000149-000101  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Banana with Emmentaler pairing" ;
@@ -42451,11 +42447,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000151 ;
         :hasRelatedIngredient  :007170 ;
         :matchScore            "0.00558035727590322"^^xsd:double .
-
-:5537f907-115a-4c0d-887a-746ecb87d3c5
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :spicy_aroma ;
-        :sensoryValue          "1.5"^^xsd:double .
 
 :000155-000801  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lime with Cocoa Powder pairing" ;
@@ -42499,10 +42490,9 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.0785122662782669"^^xsd:double .
 
-:pea_aroma  rdf:type     :SensoryDescriptor ;
-        skos:prefLabel   "pea_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+:pea_aroma  rdf:type    :SensoryDescriptor ;
+        skos:prefLabel  "pea_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000136-000046  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Blueberry with Champignon Mushroom pairing" ;
@@ -42533,15 +42523,9 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000072 ;
         :matchScore            "0.171755731105804"^^xsd:double .
 
-:fa27db00-9047-473c-b323-c3bae92cffc6
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :apple_aroma ;
-        :sensoryValue          "1.625"^^xsd:double .
-
 :citrus_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "citrus_aroma"@en ;
-        :aromaIntensity  "1.25"^^xsd:double ;
-        :hasAromaType    :citrus .
+        skos:prefLabel  "citrus_aroma"@en ;
+        :hasAromaType   :citrus .
 
 :000876-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Vermouth with Sweet Cherry pairing" ;
@@ -42693,6 +42677,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.400000005960464"^^xsd:double .
 
+:a86a9034-e7a7-44ff-97bf-413eed7fa130
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "2.2"^^xsd:double .
+
 :006821-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Dark Chocolate with Humulus Shoot pairing" ;
         :hasKeyIngredient      :006821 ;
@@ -42705,10 +42694,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.51044774055481"^^xsd:double .
 
-:1e1410a8-0888-472a-b68c-5d9362879d5e
+:ea03b9ec-a277-4d35-a94d-e902fab8e06e
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :herbal_aroma ;
-        :sensoryValue          "14.0"^^xsd:double .
+        :hasSensoryDescriptor  :potato_aroma ;
+        :sensoryValue          "2.7"^^xsd:double .
 
 :000117-000083  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Pea with Red Bell Pepper pairing" ;
@@ -42812,16 +42801,16 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000151 ;
         :matchScore            "0.119801983237267"^^xsd:double .
 
+:580bdfdc-a3cd-4291-a482-35f8e1e1a2ff
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :green_aroma ;
+        :sensoryValue          "1.7000000000000002"^^xsd:double .
+
 :000101-005483  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Emmentaler with Humulus Shoot pairing" ;
         :hasKeyIngredient      :000101 ;
         :hasRelatedIngredient  :005483 ;
         :matchScore            "0.200000002980232"^^xsd:double .
-
-:eb091a25-7fe1-4ded-b68d-2c04d42cf670
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :spicy_aroma ;
-        :sensoryValue          "0.44999999999999996"^^xsd:double .
 
 :000030-005545  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Ginger with Mussel pairing" ;
@@ -43096,10 +43085,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000046 ;
         :matchScore            "0.580645143985748"^^xsd:double .
 
-:843a8a1f-9578-49ed-83e2-952e174906f7
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
+:16da755a-9e6e-4f95-8a3d-f15a8c22b8a4
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :smoky_aroma ;
+        :sensoryValue          "0.44999999999999996"^^xsd:double .
 
 :000886-000886  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Whisky with Whisky pairing" ;
@@ -43178,11 +43167,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000452 ;
         :matchScore            "0.300751864910126"^^xsd:double .
 
-:aca56bf0-0dee-4f8b-8895-154ed7f36417
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :milk_aroma ;
-        :sensoryValue          "5.0"^^xsd:double .
-
 :000148-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mango with Pea pairing" ;
         :hasKeyIngredient      :000148 ;
@@ -43202,9 +43186,8 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.552631556987762"^^xsd:double .
 
 :almond_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "almond_aroma"@en ;
-        :aromaIntensity  "4.5"^^xsd:double ;
-        :hasAromaType    :nutty .
+        skos:prefLabel  "almond_aroma"@en ;
+        :hasAromaType   :nutty .
 
 :000109-001968  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Pastis pairing" ;
@@ -43248,11 +43231,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005930 ;
         :matchScore            "0.283969461917877"^^xsd:double .
 
-:72b7b7f4-423c-4e6d-a65e-4c7b2a2e0074
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :herbal_aroma ;
-        :sensoryValue          "0.14"^^xsd:double .
-
 :000030-000141  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Ginger with Yellow Peach pairing" ;
         :hasKeyIngredient      :000030 ;
@@ -43263,11 +43241,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q14458220"^^xsd:anyURI ;
         skos:definition         "Strawberries are sweet, red berries with a juicy texture, commonly used in desserts, salads, and beverages."@en ;
         skos:prefLabel          "Strawberry"@en ;
-        :hasAroma               :e1c2c1ac-674b-4366-8531-b6585b7befb9 , :d5f6c769-87ed-44f2-887d-0cc0c1517927 , :794219d8-6f09-4555-b5ae-3376ffd81194 ;
+        :hasAroma               :f7cf8e9b-c53f-4e56-82fa-849f611df559 , :4b85ce33-1464-431d-91c0-2c352552ba6a , :4b327663-c8e4-4686-99b8-e25ec916f530 ;
         :hasFunctionalBenefit   :Satiety , :Antioxidant , :Energy , :Brain , :Minerals , :Cardiovascular , :Diabetic , :Bone , :Probiotic , :Digestion , :Nervous-system , :Immunity , :Weight-loss ;
         :hasIngredientCategory  :icat:000088 ;
-        :hasTaste               :293065fd-c510-46a3-b76d-288cea845325 , :2b0874fe-04d1-4c4f-bd48-c6a8da384b52 ;
-        :hasTexture             :6ed8ef42-a2ae-4f13-84d3-11cc17a9c31d .
+        :hasTaste               :757ec09a-7430-436b-b92f-9d063bfdd8bf , :e00d2323-c2d8-4f35-8475-7864684e9a54 ;
+        :hasTexture             :61c04ce3-4073-4aa6-a6c3-b7aa46556b5c .
 
 :001008-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Milk Chocolate with Orange pairing" ;
@@ -43292,11 +43270,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000865 ;
         :hasRelatedIngredient  :007109 ;
         :matchScore            "0.275000005960464"^^xsd:double .
-
-:79419599-237c-4621-ab06-744f88a13139
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :floral_aroma ;
-        :sensoryValue          "1.05"^^xsd:double .
 
 :000157-000520  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Brussels Sprouts pairing" ;
@@ -43454,6 +43427,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003143 ;
         :matchScore            "0.0251256283372641"^^xsd:double .
 
+:4b85ce33-1464-431d-91c0-2c352552ba6a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :strawberry_aroma ;
+        :sensoryValue          "18.4"^^xsd:double .
+
 :000161-007109  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Watermelon with Fig pairing" ;
         :hasKeyIngredient      :000161 ;
@@ -43544,6 +43522,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000938 ;
         :matchScore            "0.107142858207226"^^xsd:double .
 
+:9029fe44-e4e8-4c73-a97f-3c71aac0c2e8
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :mushroom_aroma ;
+        :sensoryValue          "0.4"^^xsd:double .
+
 :007105-000252  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Sweet Potato pairing" ;
         :hasKeyIngredient      :007105 ;
@@ -43598,6 +43581,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003143 ;
         :matchScore            "0.272727280855179"^^xsd:double .
 
+:9fd0f3b7-cf43-4540-94d7-62fc2622e61b
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fishy_aroma ;
+        :sensoryValue          "1.0"^^xsd:double .
+
 :005842-000413  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Garlic Puree with Apple 'Jonagold' pairing" ;
         :hasKeyIngredient      :005842 ;
@@ -43610,10 +43598,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :008970 ;
         :matchScore            "0.0215384606271982"^^xsd:double .
 
-:d28ef172-b2ea-42f2-81ca-57b9374b01a4
+:baaa3023-f9d9-41eb-97a4-c8769e837235
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :cabbage_aroma ;
-        :sensoryValue          "4.75"^^xsd:double .
+        :hasSensoryDescriptor  :apple_aroma ;
+        :sensoryValue          "9.1"^^xsd:double .
 
 :005760-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Veal with Oyster Mushroom pairing" ;
@@ -43625,19 +43613,13 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q961769"^^xsd:anyURI ;
         skos:definition         "A creamy, green fruit with a buttery texture, often used in salads, spreads, and various dishes."@en ;
         skos:prefLabel          "Avocado"@en ;
-        :hasAroma               :e2a05a4f-4189-4524-8fda-da29de1dbde4 , :219f5c31-3efb-43ef-af52-94bbc9ba87bd , :f372b291-2b1d-4ca8-a2d5-bc7eb7750e05 , :7c12e8b7-773c-45b1-b071-45115c1dacc9 ;
+        :hasAroma               :f994e140-4a66-44b2-af9c-07ef974a2ff4 , :13f3d699-dbb0-4204-8fdf-e654b01619e1 , :f7bf4dd9-caa0-4378-87ed-290162b02894 , :e96e0bd3-14ec-4ea1-a4a2-95544baccc5a ;
         :hasFunctionalBenefit   :Probiotic , :Energy , :Diabetic , :Digestion , :Cardiovascular , :Bone , :Minerals , :Vitamins , :Brain , :Stress , :Satiety ;
         :hasIngredientCategory  :icat:000129 .
 
-:c6bad883-2d29-4f2b-a266-68f8197cfd30
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "2.55"^^xsd:double .
-
 :cucumber_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "cucumber_aroma"@en ;
-        :aromaIntensity  "5.5"^^xsd:double ;
-        :hasAromaType    :green .
+        skos:prefLabel  "cucumber_aroma"@en ;
+        :hasAromaType   :green .
 
 :000090-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cheddar with Blueberry pairing" ;
@@ -43761,10 +43743,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q165112"^^xsd:anyURI ;
         skos:definition         "Popcorn is a type of corn that puffs up when heated, resulting in a light and crunchy snack."@en ;
         skos:prefLabel          "Popcorn"@en ;
-        :hasAroma               :4c53b07d-8fbc-4eba-a449-c32f53ee5fb2 , :d4952150-6524-4c73-af9b-361b56ae9049 , :aa4a3a2d-1d71-4e24-a051-1d4ce719c192 , :984417c7-e490-4bb3-9005-381bed06f619 ;
+        :hasAroma               :74e84ce3-af64-4ed9-b043-8cc684248fe6 , :44043348-5d68-43d0-a7f0-f039b839b8fc , :a3339e3e-6c05-4548-b169-fdfa2bf1008c , :2e49d59d-44b8-4750-a2ed-374e530a2602 ;
         :hasFunctionalBenefit   :Energy , :Brain , :Satiety , :Antioxidant , :Bone ;
         :hasIngredientCategory  :icat:000111 ;
-        :hasTexture             :999b740c-eace-4761-8e72-c7c4511b6b26 .
+        :hasTexture             :9139bc78-fc31-464e-a3c3-e52712fc85ef .
 
 :000013-000472  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Full-fat Yogurt with Camembert pairing" ;
@@ -43892,11 +43874,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000082 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
 
-:8a19792b-3494-4c57-9132-fed908758c59
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "3.5"^^xsd:double .
-
 :000109-000072  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Lemon pairing" ;
         :hasKeyIngredient      :000109 ;
@@ -43987,21 +43964,20 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005622 ;
         :matchScore            "0.113207548856735"^^xsd:double .
 
-:d4343bad-0996-4590-8651-b1ff0caf0931
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "2.55"^^xsd:double .
-
 :000938-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Asparagus with Mustard pairing" ;
         :hasKeyIngredient      :000938 ;
         :hasRelatedIngredient  :000040 ;
         :matchScore            "0.16666667163372"^^xsd:double .
 
-:onion_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "onion_aroma"@en ;
-        :aromaIntensity  "16.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+:e76a6d57-2cf5-457d-a65a-fd38da4d2817
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :chocolate_aroma ;
+        :sensoryValue          "9.0"^^xsd:double .
+
+:onion_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "onion_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :Flavour  rdf:type       owl:Class ;
         rdfs:seeAlso     <https://www.foodpairing.com/industry/glossary/definition/flavor/> ;
@@ -44013,6 +43989,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000887 ;
         :hasRelatedIngredient  :000161 ;
         :matchScore            "0.000615384604316205"^^xsd:double .
+
+:45da55a6-074f-4de6-9a74-e96f8defc324
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "4.5"^^xsd:double .
 
 :000040-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Mustard with Pea pairing" ;
@@ -44071,6 +44052,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :002530 ;
         :hasRelatedIngredient  :001008 ;
         :matchScore            "0.200000002980232"^^xsd:double .
+
+:4ef3c7a8-516b-4f79-b6a1-9df42dd54800
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :berry_aroma ;
+        :sensoryValue          "9.5"^^xsd:double .
 
 :007170-000313  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Honey pairing" ;
@@ -44156,10 +44142,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000144 ;
         :matchScore            "0.0749019607901573"^^xsd:double .
 
-:bac6bd4d-9418-4376-bb87-2b4f50765aae
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
+:f795b808-30e9-4d89-96ac-a35fcc095907
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :honey_aroma ;
+        :sensoryValue          "2.0"^^xsd:double .
 
 :000213-000355  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Cabbage with Sweet Corn pairing" ;
@@ -44411,6 +44397,16 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000046 ;
         :matchScore            "0.112000003457069"^^xsd:double .
 
+:8f2d4762-1d7e-4aa7-9fc4-70515081ae9e
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :peach_aroma ;
+        :sensoryValue          "22.4"^^xsd:double .
+
+:0e6a84d8-603f-417b-ab39-521029993852
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :woody_aroma ;
+        :sensoryValue          "0.05"^^xsd:double .
+
 :000281-001218  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Coriander Seed with Cod pairing" ;
         :hasKeyIngredient      :000281 ;
@@ -44422,11 +44418,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000865 ;
         :hasRelatedIngredient  :000078 ;
         :matchScore            "0.0437499992549419"^^xsd:double .
-
-:a1b74fe7-93f6-4d8c-afe5-dd84ea890303
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :soft_texture ;
-        :sensoryValue          true .
 
 :000181-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Spinach with Lime pairing" ;
@@ -44563,11 +44554,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :003290 ;
         :matchScore            "0.0909090936183929"^^xsd:double .
 
-:45ae2126-e543-4fab-8246-0847284063f9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :milk_aroma ;
-        :sensoryValue          "1.6"^^xsd:double .
-
 :000109-000030  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Basil Leaf with Ginger pairing" ;
         :hasKeyIngredient      :000109 ;
@@ -44628,10 +44614,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001624 ;
         :matchScore            "0.00770992366597056"^^xsd:double .
 
-:974b991c-a7e2-4ea7-b156-e17a6cc8a600
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "1.5"^^xsd:double .
+:61c04ce3-4073-4aa6-a6c3-b7aa46556b5c
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :juicy_texture ;
+        :sensoryValue          true .
 
 :008970-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brewed Coffee with Sweet Cherry pairing" ;
@@ -44667,7 +44653,7 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q33913"^^xsd:anyURI ;
         skos:definition         "A fragrant herb with a lemony scent, often used in Asian cuisine to add a citrusy flavor to dishes."@en ;
         skos:prefLabel          "Lemongrass"@en ;
-        :hasAroma               :b5eacf6b-d9f4-445f-8859-ae51d139d39a , :7c298028-faf1-4bcc-a27c-afedeecbf9da ;
+        :hasAroma               :1bf685a4-5114-4929-bc6b-beebe8cd8fac , :8e97807f-038b-4da4-a7cf-af7327416ef6 ;
         :hasFunctionalBenefit   :Immunity , :Sleep , :Stress , :Antioxidant , :Energy ;
         :hasIngredientCategory  :icat:000094 .
 
@@ -44695,11 +44681,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000801 ;
         :matchScore            "0.0640000030398369"^^xsd:double .
 
-:52457140-48db-4eaf-bc2b-96cbb299b574
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :fatty_aroma ;
-        :sensoryValue          "1.7999999999999998"^^xsd:double .
-
 :000938-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Asparagus with Oyster pairing" ;
         :hasKeyIngredient      :000938 ;
@@ -44718,21 +44699,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000306 ;
         :matchScore            "0.0399999991059303"^^xsd:double .
 
-:a1a376b8-b1f1-4fe8-b669-a20d21aa9347
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sour_taste ;
-        :sensoryValue          "2.5"^^xsd:double .
-
 :000920-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Sweet Cherry pairing" ;
         :hasKeyIngredient      :000920 ;
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.27678570151329"^^xsd:double .
-
-:04d6b89d-6fe2-4480-8b79-79543c216803
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "3.0"^^xsd:double .
 
 :000083-000017  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Tomato pairing" ;
@@ -44925,10 +44896,9 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000886 ;
         :matchScore            "0.136363640427589"^^xsd:double .
 
-:beany_aroma  rdf:type   :SensoryDescriptor ;
-        skos:prefLabel   "beany_aroma"@en ;
-        :aromaIntensity  "3.0"^^xsd:double ;
-        :hasAromaType    :vegetable .
+:beany_aroma  rdf:type  :SensoryDescriptor ;
+        skos:prefLabel  "beany_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :003246-001218  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cow Mozzarella with Cod pairing" ;
@@ -45067,6 +45037,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000159 ;
         :matchScore            "0.0783085376024246"^^xsd:double .
 
+:757a5690-02a6-48dc-b028-e1db38424d88
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :vanilla_aroma ;
+        :sensoryValue          "0.07500000000000001"^^xsd:double .
+
 :000873-000515  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Cherry with Oyster Mushroom pairing" ;
         :hasKeyIngredient      :000873 ;
@@ -45126,11 +45101,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000873 ;
         :hasRelatedIngredient  :000135 ;
         :matchScore            "0.170886069536209"^^xsd:double .
-
-:056189cf-a030-4a62-b2d5-20a648de1c64
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :tropical_aroma ;
-        :sensoryValue          "7.5"^^xsd:double .
 
 :000163-000873  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cantaloupe Melon with Sweet Cherry pairing" ;
@@ -45246,6 +45216,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000013 ;
         :matchScore            "0.16721311211586"^^xsd:double .
 
+:810b3dcb-2b1b-46b5-bc99-e0bbe2edccfb
+        rdf:type               :Texture ;
+        :hasSensoryDescriptor  :starchy_texture ;
+        :sensoryValue          true .
+
 :hasTexture  rdf:type       owl:ObjectProperty ;
         rdfs:domain         :Ingredient ;
         rdfs:range          :Texture ;
@@ -45270,6 +45245,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :001755 ;
         :hasRelatedIngredient  :002530 ;
         :matchScore            "0.0500000007450581"^^xsd:double .
+
+:969322ea-02cd-46d8-825a-a871d3b05194
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sweet_taste ;
+        :sensoryValue          "0.2"^^xsd:double .
 
 :000157-000136  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Orange with Blueberry pairing" ;
@@ -45313,11 +45293,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000357 ;
         :matchScore            "0.647058844566345"^^xsd:double .
 
-:99a2bcb6-528f-4e00-a250-f20c718e0976
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "3.5"^^xsd:double .
-
 :000144-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Plum with Brewed Coffee pairing" ;
         :hasKeyIngredient      :000144 ;
@@ -45348,11 +45323,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.230769231915474"^^xsd:double .
 
-:30f571bc-7564-4ccb-a917-53350d041cea
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :green_aroma ;
-        :sensoryValue          "4.25"^^xsd:double .
-
 :000046-008970  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Brewed Coffee pairing" ;
         :hasKeyIngredient      :000046 ;
@@ -45375,11 +45345,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q38645"^^xsd:anyURI ;
         skos:definition         "A juicy and refreshing fruit with a sweet, hydrating taste, commonly eaten fresh."@en ;
         skos:prefLabel          "Watermelon"@en ;
-        :hasAroma               :09535de2-0bdd-4144-8087-a07641673e9f , :e1eb78d9-e4aa-4690-91ca-ab1e463824b2 , :2effeb6e-2dca-4d4e-a7ee-995d440e27da , :9c83c232-3b34-458e-a73a-a71023c82eee ;
+        :hasAroma               :73c42013-8eab-4e3a-af7a-4849611d09ab , :7b003183-f584-448f-bb5d-6562693f7e8f , :ba17526f-042b-410b-a36b-7c84a3a5a199 , :2623e44e-9c2b-4341-8aec-34337bdb40dd ;
         :hasFunctionalBenefit   :Antioxidant , :Digestion , :Satiety , :Brain , :Vitamins , :Energy , :Immunity , :Stress , :Bone , :Minerals , :Cardiovascular ;
         :hasIngredientCategory  :icat:000090 ;
-        :hasTaste               :cddf7cf2-894d-4123-bbab-df6918499a4c , :900de077-9305-45ae-b500-32516a8fbf92 ;
-        :hasTexture             :db2baa60-8bd2-4f88-bca2-1fc584742b43 , :f1fdd70e-4ba1-4480-84de-78b940aca396 .
+        :hasTaste               :fd920290-7949-4394-829d-7ac7180733b9 , :73b9c209-a9aa-4279-87b2-691d676e51e1 ;
+        :hasTexture             :3e67f734-9228-4ea3-86c1-2ea04e7c9cf4 , :daf14e93-fdf9-4c3b-b5b1-771e8b0441dd .
 
 :000787-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vanilla 'Bourbon' with Cheddar pairing" ;
@@ -45434,6 +45404,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000078 ;
         :hasRelatedIngredient  :000873 ;
         :matchScore            "0.605882346630096"^^xsd:double .
+
+:0f8dccd4-2873-4d9a-b084-e3b597522eb8
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :fatty_taste ;
+        :sensoryValue          "0.4"^^xsd:double .
 
 :000840-000142  rdf:type       :IngredientPairing ;
         skos:prefLabel         "London Dry Gin with Yellow Nectarine pairing" ;
@@ -45519,6 +45494,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000090 ;
         :matchScore            "0.00370370363816619"^^xsd:double .
 
+:e2e63fab-ff74-47f5-ab0f-c588650a91a6
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :herbal_aroma ;
+        :sensoryValue          "1.4000000000000001"^^xsd:double .
+
 :000046-000030  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Champignon Mushroom with Ginger pairing" ;
         :hasKeyIngredient      :000046 ;
@@ -45549,11 +45529,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000865 ;
         :matchScore            "0.0607348904013634"^^xsd:double .
 
-:984417c7-e490-4bb3-9005-381bed06f619
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :popcorn_aroma ;
-        :sensoryValue          "0.17500000000000002"^^xsd:double .
-
 :000104-007170  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Goat Cheese with Tequila Silver pairing" ;
         :hasKeyIngredient      :000104 ;
@@ -45571,6 +45546,16 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000181 ;
         :hasRelatedIngredient  :005509 ;
         :matchScore            "0.370370358228683"^^xsd:double .
+
+:bc07b983-cb85-49f8-88d9-0e0141e4feac
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "3.8"^^xsd:double .
+
+:37960029-32a6-4ac3-961e-47f3b48cb9cb
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :fruity_aroma ;
+        :sensoryValue          "1.8"^^xsd:double .
 
 :001218  rdf:type               :Ingredient ;
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13194939"^^xsd:anyURI ;
@@ -45626,6 +45611,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :007109 ;
         :hasRelatedIngredient  :003246 ;
         :matchScore            "0.618421077728271"^^xsd:double .
+
+:be787008-5953-4b1d-9c2c-c2f9087443c7
+        rdf:type               :Taste ;
+        :hasSensoryDescriptor  :sour_taste ;
+        :sensoryValue          "2.3"^^xsd:double .
 
 :001448-000117  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Jasmine Tea with Pea pairing" ;
@@ -45697,16 +45687,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005760 ;
         :hasRelatedIngredient  :005942 ;
         :matchScore            "0.14514285326004"^^xsd:double .
-
-:f3a443d1-1ac3-474a-ae8f-2d8e15158137
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :bitter_taste ;
-        :sensoryValue          "0.1"^^xsd:double .
-
-:e2b0f424-5585-4bcf-a963-14d0c06d6740
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
 
 :007105-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Acacia Honey with Cheddar pairing" ;
@@ -45832,11 +45812,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         skos:definition  "Relates to edible flowers used in cooking, garnishing, or flavoring food and beverages."@en ;
         skos:prefLabel   "Flowers Category"@en .
 
-:377a5920-acd9-4319-bfd2-5050d108a6ca
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :honey_aroma ;
-        :sensoryValue          "2.0"^^xsd:double .
-
 :003143-000215  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Beetroot pairing" ;
         :hasKeyIngredient      :003143 ;
@@ -45915,11 +45890,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :006002 ;
         :matchScore            "0.00754716992378235"^^xsd:double .
 
-:92e9e5dd-8445-44a5-8eae-0a4a99ab2b44
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :sweet_taste ;
-        :sensoryValue          "3.0"^^xsd:double .
-
 :000141-000938  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Peach with White Asparagus pairing" ;
         :hasKeyIngredient      :000141 ;
@@ -45968,11 +45938,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000157 ;
         :matchScore            "0.322222232818604"^^xsd:double .
 
-:d2bfd320-e377-404b-b545-4a7f3ae27ca5
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pine_aroma ;
-        :sensoryValue          "6.75"^^xsd:double .
-
 :005675-000163  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Turkey with Cantaloupe Melon pairing" ;
         :hasKeyIngredient      :005675 ;
@@ -45998,9 +45963,8 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :matchScore            "0.16666667163372"^^xsd:double .
 
 :cabbage_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "cabbage_aroma"@en ;
-        :aromaIntensity  "9.5"^^xsd:double ;
-        :hasAromaType    :vegetable .
+        skos:prefLabel  "cabbage_aroma"@en ;
+        :hasAromaType   :vegetable .
 
 :000252-000107  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Sweet Potato with Gruyère pairing" ;
@@ -46090,16 +46054,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000082 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.203999996185303"^^xsd:double .
-
-:796e6b40-6a05-4652-875e-bb29fd083291
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :woody_aroma ;
-        :sensoryValue          "0.15"^^xsd:double .
-
-:15e042c9-23a0-4a83-b6f7-2a0c62d990e2
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :citrus_aroma ;
-        :sensoryValue          "0.75"^^xsd:double .
 
 :000055-000151  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Chorizo with Pineapple pairing" ;
@@ -46329,16 +46283,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000313 ;
         :matchScore            "0.174326464533806"^^xsd:double .
 
-:b7c3541a-be23-482a-a7f2-47fbdf0ac3ff
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :mushroom_aroma ;
-        :sensoryValue          "0.4"^^xsd:double .
-
-:b7c693be-9c02-46b3-926d-a5d66d5bfb1a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :celery_aroma ;
-        :sensoryValue          "22.0"^^xsd:double .
-
 :000159-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Grapefruit with Mustard pairing" ;
         :hasKeyIngredient      :000159 ;
@@ -46493,31 +46437,15 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000083 ;
         :matchScore            "0.061224490404129"^^xsd:double .
 
-:72682989-b1b2-4195-a539-e5da35bf0c3e
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :lemon_aroma ;
-        :sensoryValue          "0.75"^^xsd:double .
-
 :coffee_aroma  rdf:type  :SensoryDescriptor ;
-        skos:prefLabel   "coffee_aroma"@en ;
-        :aromaIntensity  "4.0"^^xsd:double ;
-        :hasAromaType    :roasted .
+        skos:prefLabel  "coffee_aroma"@en ;
+        :hasAromaType   :roasted .
 
 :003143-000155  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Fourme D'Ambert with Lime pairing" ;
         :hasKeyIngredient      :003143 ;
         :hasRelatedIngredient  :000155 ;
         :matchScore            "0.100000001490116"^^xsd:double .
-
-:072fcf01-ec9d-4888-9209-0d53adc556af
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
-
-:4665e287-f5c6-49e7-8221-f115bdbfdce8
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :hard_texture ;
-        :sensoryValue          true .
 
 :003246-000157  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cow Mozzarella with Orange pairing" ;
@@ -46651,11 +46579,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001959 ;
         :matchScore            "0.0746705681085587"^^xsd:double .
 
-:36f5ec78-28c8-4900-98da-28cb4f9a9cc9
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :anise_aroma ;
-        :sensoryValue          "2.75"^^xsd:double .
-
 :005942-000865  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Baguette with Sake pairing" ;
         :hasKeyIngredient      :005942 ;
@@ -46673,11 +46596,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005930 ;
         :hasRelatedIngredient  :000182 ;
         :matchScore            "0.0152046782895923"^^xsd:double .
-
-:db0599c1-05ac-4643-ae3e-c41137e8f87a
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :roasted_aroma ;
-        :sensoryValue          "0.525"^^xsd:double .
 
 :icat:000106  rdf:type   skos:Concept , :IngredientCategory ;
         skos:broader     :icat:000019 ;
@@ -46756,21 +46674,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :001755 ;
         :matchScore            "0.217821776866913"^^xsd:double .
 
-:50f14785-acf5-48f2-be53-88838594f1ac
-        rdf:type               :Taste ;
-        :hasSensoryDescriptor  :umami_taste ;
-        :sensoryValue          "0.3"^^xsd:double .
-
 :000142-000213  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Nectarine with Red Cabbage pairing" ;
         :hasKeyIngredient      :000142 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0806451588869095"^^xsd:double .
-
-:f4cc5c03-b7f3-49fd-88a5-dcdc8968385f
-        rdf:type               :Texture ;
-        :hasSensoryDescriptor  :juicy_texture ;
-        :sensoryValue          true .
 
 :005483-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Humulus Shoot with Spinach pairing" ;
@@ -46897,11 +46805,21 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000181 ;
         :matchScore            "0.105527639389038"^^xsd:double .
 
+:1f9b3e8e-0f49-4d7c-9739-f22e37eb6893
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :pine_aroma ;
+        :sensoryValue          "0.45"^^xsd:double .
+
 :001218-007088  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cod with Armagnac pairing" ;
         :hasKeyIngredient      :001218 ;
         :hasRelatedIngredient  :007088 ;
         :matchScore            "0.142857149243355"^^xsd:double .
+
+:8be1669b-22fb-4a8d-9061-41c0959f383a
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :thyme_aroma ;
+        :sensoryValue          "12.0"^^xsd:double .
 
 :000887-000472  rdf:type       :IngredientPairing ;
         skos:prefLabel         "White Chocolate with Camembert pairing" ;
@@ -46939,11 +46857,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000109 ;
         :matchScore            "0.465116292238235"^^xsd:double .
 
-:22453277-a8fe-4105-8600-958a609af6b7
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :pungent_aroma ;
-        :sensoryValue          "1.05"^^xsd:double .
-
 :000072-000181  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Lemon with Spinach pairing" ;
         :hasKeyIngredient      :000072 ;
@@ -46955,6 +46868,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :005930 ;
         :hasRelatedIngredient  :000887 ;
         :matchScore            "0.187134504318237"^^xsd:double .
+
+:3f4693c5-332e-42fc-83e1-418c6a6161d5
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :caramel_aroma ;
+        :sensoryValue          "0.6749999999999999"^^xsd:double .
 
 :000920-003246  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Cucumber with Cow Mozzarella pairing" ;
@@ -46985,6 +46903,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000017 ;
         :hasRelatedIngredient  :001696 ;
         :matchScore            "0.125707104802132"^^xsd:double .
+
+:7caf1b37-7fdb-4ba8-864f-344c98de55b4
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :citrus_aroma ;
+        :sensoryValue          "0.75"^^xsd:double .
 
 :000159-006473  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Yellow Grapefruit with Oyster pairing" ;
@@ -47051,6 +46974,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000155 ;
         :hasRelatedIngredient  :000213 ;
         :matchScore            "0.0666666701436043"^^xsd:double .
+
+:369d88ce-0409-466b-98ae-84bc1c5d4306
+        rdf:type               :Aroma ;
+        :hasSensoryDescriptor  :floral_aroma ;
+        :sensoryValue          "5.25"^^xsd:double .
 
 :000083-000040  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Red Bell Pepper with Mustard pairing" ;
@@ -47181,11 +47109,11 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         rdfs:seeAlso            "http://www.wikidata.org/entity/Q13191"^^xsd:anyURI ;
         skos:definition         "Oranges are round, citrus fruits with a sweet and tangy flavor, commonly eaten fresh or used in juices and desserts."@en ;
         skos:prefLabel          "Orange"@en ;
-        :hasAroma               :40bf3cf0-baf2-4270-98aa-74ec77a1125d , :14692030-96a9-4a63-b34b-50e1ad61ab4c , :657baf34-d7c0-47af-ab2a-9cc1ac55981c ;
-        :hasFunctionalBenefit   :Satiety , :Weight-gain , :Energy , :Minerals , :Sleep , :Cardiovascular , :Stress , :Prebiotic , :Ageing , :Brain , :Diabetic , :Nervous-system , :Digestion , :Antibacterial , :Probiotic , :Vitamins , :Antioxidant , :Immunity , :Weight-loss , :Bone ;
+        :hasAroma               :cf55bf8f-87c3-4b9e-bc47-aa5cad225d81 , :a0298dd4-28f1-4fb1-8ff8-b090ec8a5ca2 , :c6d27884-5d0f-4b54-8ba5-fc76763fc48a ;
+        :hasFunctionalBenefit   :Satiety , :Weight-gain , :Energy , :Sleep , :Minerals , :Cardiovascular , :Stress , :Prebiotic , :Ageing , :Digestion , :Brain , :Diabetic , :Nervous-system , :Antibacterial , :Probiotic , :Vitamins , :Antioxidant , :Immunity , :Weight-loss , :Bone ;
         :hasIngredientCategory  :icat:000089 ;
-        :hasTaste               :c5478fd9-f6d7-4d29-bde8-a5f491b6b7c2 , :e02b799c-be09-4674-8d5c-ec7395d204c2 ;
-        :hasTexture             :f0ffa4b0-7cee-41a1-b8b8-4ab35ca091d7 .
+        :hasTaste               :bc07b983-cb85-49f8-88d9-0e0141e4feac , :1a4e48bb-6019-4cde-9393-7e45234db584 ;
+        :hasTexture             :142c1b58-7b71-43a8-8f84-197b766bd751 .
 
 :003290-000096  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Brie with Chives pairing" ;
@@ -47276,11 +47204,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :005842 ;
         :matchScore            "0.113323569297791"^^xsd:double .
 
-:16075913-b852-44aa-997f-27eddea7f687
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :banana_aroma ;
-        :sensoryValue          "1.7999999999999998"^^xsd:double .
-
 :006473-000090  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Oyster with Cheddar pairing" ;
         :hasKeyIngredient      :006473 ;
@@ -47299,10 +47222,10 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasRelatedIngredient  :000520 ;
         :matchScore            "0.375"^^xsd:double .
 
-:3edf0420-e1fd-4d8c-b48f-5bbb767b4010
+:be238809-990f-41c2-842c-9175626c8066
         rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :caramel_aroma ;
-        :sensoryValue          "0.6749999999999999"^^xsd:double .
+        :hasSensoryDescriptor  :woody_aroma ;
+        :sensoryValue          "0.5"^^xsd:double .
 
 :007170-000017  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Tequila Silver with Tomato pairing" ;
@@ -47327,11 +47250,6 @@ dct:publisher  rdf:type  owl:AnnotationProperty .
         :hasKeyIngredient      :000281 ;
         :hasRelatedIngredient  :000055 ;
         :matchScore            "0.0444444455206394"^^xsd:double .
-
-:64704272-8f20-45de-92f6-ef3f2d11a7b6
-        rdf:type               :Aroma ;
-        :hasSensoryDescriptor  :potato_aroma ;
-        :sensoryValue          "2.7"^^xsd:double .
 
 :001624-000123  rdf:type       :IngredientPairing ;
         skos:prefLabel         "Vodka with Rosemary pairing" ;


### PR DESCRIPTION
This PR contains only the `README.md` that contains a handful of practical use cases for the Inspire KG, in the form of SPARQL queries. 

In order to test the queries out:
1. Go to our [GraphDB instance on staging](https://graphdb.internal.staging.foodpairing.com/). 
2. Make sure the `inspire` repository is selected (top-right corner).
3. Go to the SPARQL tab.
4. Run the queries (i.e., copy-paste the SPARQL excerpts and press `RUN`) and verify whether a result-set is retrieved.
5. Suggest additional SPARQL queries that may be illustrative enough for potential end users.